### PR TITLE
Initialize FastAPI application with logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 .vscode
 .env
+.venv/
+venv/
 services/src/config/interactive-house-d3e5c-firebase-adminsdk-fbsvc-594de405b5.json
 __pycache__/
 *.py[cod]
 *tmpclaude*
-.venv/

--- a/services/src/main.py
+++ b/services/src/main.py
@@ -1,10 +1,13 @@
 from fastapi import FastAPI
 import logging
+import os
 
-# Basic logging setup
+LOG_LEVEL_STR = os.getenv("LOG_LEVEL", "INFO").upper()
+LOG_LEVEL = getattr(logging, LOG_LEVEL_STR, logging.INFO)
+
 logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s - %(message)s"
+    level=LOG_LEVEL,
+    format="%(asctime)s - %(levelname)s - %(message)s",
 )
 
 logger = logging.getLogger(__name__)
@@ -19,3 +22,4 @@ def startup_event():
 def root():
     logger.info("GET / called")
     return {"status": "ok"}
+


### PR DESCRIPTION
Initial server entrypoint with startup and request logging

## Summary
Added FastAPI app entrypoint in `services/src/main.py`
Server logs when it starts
incoming requests are logged (root endpoint)

## Why
This sets up the foundation for the server and enables basic observability early in the project.

## Test
Ran locally: uvicorn services.src.main:app --reload
Verified: GET http://127.0.0.1:8000/health returns {"status":"ok"}
Verified logs appear in terminal when hitting endpoints

## Checklist
- [x] Small, focused change
- [x] Tested locally
- [x] Linked to issue

Related Issue: #21 
