### PR TITLE
Implement endpoint to register new device #28

### DIFF
--- a/services/src/firebase/device_store.py
+++ b/services/src/firebase/device_store.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+from typing import Any
+
+# Enkel in-memory store (placeholder tills Firebase kopplas på riktigt)
+_DEVICES: dict[str, dict[str, Any]] = {}
+
+
+def list_devices() -> list[dict[str, Any]]:
+    return list(_DEVICES.values())
+
+
+def get_device(device_uuid: str) -> dict[str, Any] | None:
+    return _DEVICES.get(device_uuid)
+
+
+def register_device(device_uuid: str, data: dict[str, Any]) -> dict[str, Any]:
+    # sparar/uppdaterar device
+    payload = {"device_uuid": device_uuid, **data}
+    _DEVICES[device_uuid] = payload
+    return payload

--- a/services/src/routes/device_routes.py
+++ b/services/src/routes/device_routes.py
@@ -1,6 +1,9 @@
 from fastapi import APIRouter, Depends
 from services.src.services.auth_service import optional_user
 from services.src.utils.logger import get_logger
+from pydantic import BaseModel, Field
+from services.src.services import device_service
+
 
 router = APIRouter(
     prefix="/devices",
@@ -9,21 +12,30 @@ router = APIRouter(
 
 logger = get_logger(__name__)
 
-# -------------------------
+
+class RegisterDeviceBody(BaseModel):
+    device_type: str | None = None
+    capabilities: list[str] = Field(default_factory=list)
+
+
 # Devices
-# -------------------------
+#
 
 @router.get("")
 def list_devices(type: str | None = None, user=Depends(optional_user)):
     logger.info("GET /devices")
-    # TODO: return device_service.list_devices(user=user, device_type=type)
-    return {"todo": "list_devices service call"}
+    return device_service.list_devices(device_type=type)
+
 
 @router.post("/{deviceUuid}")
-def register_device(deviceUuid: str, user=Depends(optional_user)):
+def register_device(deviceUuid: str, payload: RegisterDeviceBody, user=Depends(optional_user)):
     logger.info(f"POST /devices/{deviceUuid}")
-    # TODO: return device_service.register_device(deviceUuid, payload, user)
-    return {"todo": "register_device service call", "deviceUuid": deviceUuid}
+    return device_service.register_device(
+        device_uuid=deviceUuid,
+        device_type=payload.device_type,
+        capabilities=payload.capabilities,
+    )
+
 
 @router.get("/{deviceUuid}")
 def get_device(deviceUuid: str, user=Depends(optional_user)):
@@ -43,9 +55,7 @@ def delete_device(deviceUuid: str, user=Depends(optional_user)):
     # TODO: return device_service.delete_device(deviceUuid, user)
     return {"todo": "delete_device service call", "deviceUuid": deviceUuid}
 
-# -------------------------
 # Commands
-# -------------------------
 
 @router.post("/{deviceUuid}/commands")
 def post_command(deviceUuid: str, user=Depends(optional_user)):
@@ -53,9 +63,7 @@ def post_command(deviceUuid: str, user=Depends(optional_user)):
     # TODO: return command_service.queue_command(deviceUuid, payload, user)
     return {"todo": "queue_command service call", "deviceUuid": deviceUuid}
 
-# -------------------------
 # Health
-# -------------------------
 
 @router.post("/{deviceUuid}/heartbeat")
 def heartbeat(deviceUuid: str):
@@ -63,9 +71,7 @@ def heartbeat(deviceUuid: str):
     # TODO: return device_service.heartbeat(deviceUuid)
     return {"todo": "heartbeat service call", "deviceUuid": deviceUuid}
 
-# -------------------------
 # Events (placeholder)
-# -------------------------
 
 @router.get("/events")
 def events():

--- a/services/src/services/auth_service.py
+++ b/services/src/services/auth_service.py
@@ -1,4 +1,6 @@
+from fastapi import Query
+from typing import Optional
 
-
-def optional_user(func):
-    return None
+def optional_user(action: Optional[str] = Query(default=None, alias="func")):
+    # action innehåller värdet från ?func=...
+    ...

--- a/services/src/services/device_service.py
+++ b/services/src/services/device_service.py
@@ -1,0 +1,20 @@
+from services.src.firebase import device_store
+
+
+def list_devices(device_type: str | None = None):
+    devices = device_store.list_devices()
+    if device_type:
+        devices = [d for d in devices if d.get("device_type") == device_type]
+    return devices
+
+
+def register_device(device_uuid: str, device_type: str | None = None, capabilities: list[str] | None = None):
+    data = {
+        "device_type": device_type,
+        "capabilities": capabilities or [],
+    }
+    return device_store.register_device(device_uuid, data)
+
+
+def get_device(device_uuid: str):
+    return device_store.get_device(device_uuid)


### PR DESCRIPTION
## Summary
Implements device registration endpoint.

## What does this PR change?
- Adds POST `/api/v1/devices/{deviceUuid}`
- Adds request body validation for device type and capabilities
- Registers devices via service + store layer
- Adds GET `/api/v1/devices` to list registered devices
- Logging added for device routes

## Why
Required to support device registration for the Interactive House backend.

## Test
- Started FastAPI server locally
- Tested POST /api/v1/devices/{deviceUuid} via curl
- Tested GET /api/v1/devices returns registered devices

## Checklist
- [x] Small, focused change
- [x] Tested locally
- [x] Linked to issue

Closes #28

