### PR TITLE
Implement device heartbeat endpoint (#30)

### DIFF
--- a/services/src/firebase/device_store.py
+++ b/services/src/firebase/device_store.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+from typing import Dict, Any
+
+# In-memory store (för dev/test)
+_DEVICES: Dict[str, Dict[str, Any]] = {}
+
+
+def register_device(device_uuid: str, data: Dict[str, Any]):
+    device = {
+        "device_uuid": device_uuid,
+        "device_type": data.get("device_type"),
+        "capabilities": data.get("capabilities", []),
+    }
+    _DEVICES[device_uuid] = device
+    return device
+
+
+def get_device(device_uuid: str):
+    return _DEVICES.get(device_uuid)
+
+
+def list_devices():
+    return list(_DEVICES.values())
+
+
+def update_last_seen(device_uuid: str, timestamp: datetime):
+    device = _DEVICES.get(device_uuid)
+    if not device:
+        return {"error": "device not found", "device_uuid": device_uuid}
+
+    device["last_seen"] = timestamp.isoformat()
+    return device

--- a/services/src/routes/device_routes.py
+++ b/services/src/routes/device_routes.py
@@ -1,6 +1,9 @@
 from fastapi import APIRouter, Depends
 from services.src.services.auth_service import optional_user
 from services.src.utils.logger import get_logger
+from services.src.services import device_service
+from pydantic import BaseModel, Field
+
 
 router = APIRouter(
     prefix="/devices",
@@ -9,6 +12,11 @@ router = APIRouter(
 
 logger = get_logger(__name__)
 
+class RegisterDeviceBody(BaseModel):
+    device_type: str | None = None
+    capabilities: list[str] = Field(default_factory=list)
+
+
 # -------------------------
 # Devices
 # -------------------------
@@ -16,14 +24,18 @@ logger = get_logger(__name__)
 @router.get("")
 def list_devices(type: str | None = None, user=Depends(optional_user)):
     logger.info("GET /devices")
-    # TODO: return device_service.list_devices(user=user, device_type=type)
-    return {"todo": "list_devices service call"}
+    return device_service.list_devices(device_type=type)
+
 
 @router.post("/{deviceUuid}")
-def register_device(deviceUuid: str, user=Depends(optional_user)):
+def register_device(deviceUuid: str, payload: RegisterDeviceBody, user=Depends(optional_user)):
     logger.info(f"POST /devices/{deviceUuid}")
-    # TODO: return device_service.register_device(deviceUuid, payload, user)
-    return {"todo": "register_device service call", "deviceUuid": deviceUuid}
+    return device_service.register_device(
+        device_uuid=deviceUuid,
+        device_type=payload.device_type,
+        capabilities=payload.capabilities,
+    )
+
 
 @router.get("/{deviceUuid}")
 def get_device(deviceUuid: str, user=Depends(optional_user)):
@@ -60,8 +72,8 @@ def post_command(deviceUuid: str, user=Depends(optional_user)):
 @router.post("/{deviceUuid}/heartbeat")
 def heartbeat(deviceUuid: str):
     logger.info(f"POST /devices/{deviceUuid}/heartbeat")
-    # TODO: return device_service.heartbeat(deviceUuid)
-    return {"todo": "heartbeat service call", "deviceUuid": deviceUuid}
+    return device_service.heartbeat(deviceUuid)
+
 
 # -------------------------
 # Events (placeholder)

--- a/services/src/services/device_service.py
+++ b/services/src/services/device_service.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+from services.src.firebase import device_store
+
+
+def list_devices(device_type: str | None = None):
+    devices = device_store.list_devices()
+    if device_type:
+        devices = [d for d in devices if d.get("device_type") == device_type]
+    return devices
+
+
+def register_device(
+    device_uuid: str,
+    device_type: str | None = None,
+    capabilities: list[str] | None = None,
+):
+    data = {
+        "device_type": device_type,
+        "capabilities": capabilities or [],
+    }
+    return device_store.register_device(device_uuid, data)
+
+
+def get_device(device_uuid: str):
+    return device_store.get_device(device_uuid)
+
+
+def heartbeat(device_uuid: str):
+    return device_store.update_last_seen(device_uuid, datetime.utcnow())


### PR DESCRIPTION
## Summary
Adds a heartbeat endpoint for devices. Devices can ping the backend to update their `last_seen` timestamp.

## Why
Required for device health tracking and online/offline status.
Implements task #30.

## Test
- Started the API locally with uvicorn
- Registered a device via `POST /api/v1/devices/{deviceUuid}`
- Sent heartbeat via `POST /api/v1/devices/{deviceUuid}/heartbeat`
- Verified `last_seen` is updated and returned correctly

## Checklist
- [x] Small, focused change
- [x] I tested it
- [x] Linked issue/requirement

Related issue: #30  
Closes #30

