### PR TITLE
Added get and delete device by id

### DIFF
--- a/services/src/controllers/device_controller.py
+++ b/services/src/controllers/device_controller.py
@@ -17,16 +17,14 @@ def register_device(device_uuid: str, payload: RegisterDeviceBody):
     )
 
 def get_device(device_uuid: str):
-    # TODO: return device_service.get_device(device_uuid, user)
-    return {"todo": "get_device service call", "device_uuid": device_uuid}
+    return device_service.get_device(device_uuid)
 
 def update_device(device_uuid: str):
     # TODO: return device_service.update_device(device_uuid, payload, user)
     return {"todo": "update_device service call", "device_uuid": device_uuid}
 
 def delete_device(device_uuid: str):
-    # TODO: return device_service.delete_device(device_uuid, user)
-    return {"todo": "delete_device service call", "device_uuid": device_uuid}
+    return device_service.delete_device(device_uuid)   
 
 # -------------------------
 # Commands

--- a/services/src/firebase/device_store.py
+++ b/services/src/firebase/device_store.py
@@ -24,6 +24,8 @@ def get_device(device_uuid: str) -> Dict[str, Any] | None:
 def list_devices() -> list[Dict[str, Any]]:
     return list(_DEVICES.values())
 
+def delete_device(device_uuid: str)-> Dict[str, Any] | None: 
+    return _DEVICES.pop(device_uuid, None)
 
 def update_last_seen(device_uuid: str, timestamp: datetime) -> Dict[str, Any]:
     device = _DEVICES.get(device_uuid)

--- a/services/src/services/device_service.py
+++ b/services/src/services/device_service.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timezone
+from fastapi import HTTPException
 from services.src.firebase import device_store
+from typing import Any, Dict
 
 
 def register_device(device_uuid: str, device_type: str | None, capabilities: list[str]):
@@ -15,6 +17,24 @@ def list_devices(device_type: str | None = None):
         devices = [d for d in devices if d.get("device_type") == device_type]
     return devices
 
+def get_device(device_uuid: str)-> Dict[str, Any]:
+    device = device_store.get_device(device_uuid)
+
+    if not device:
+        raise HTTPException(status_code=404, detail="Device not found")
+
+    return device
+
+def delete_device(device_uuid:str) -> dict[str, str]:
+    device = device_store.delete_device(device_uuid)
+
+    if not device:
+        raise HTTPException(status_code=404, detail="Device not found")
+    
+    return {
+        "message": "Device deleted successfully",
+        "device_uuid": device_uuid
+    }
 
 def heartbeat(device_uuid: str):
     now = datetime.now(timezone.utc)


### PR DESCRIPTION
## Summary
Implemented endpoints for retrieving and deleting a device by device_uuid.

## Why
Required functionality for the device in the backend

## Test
Ran the FastAPI server and tested the endpoints through /docs:

GET /api/v1/devices/{device_uuid} returns device information or 404 if not found.

DELETE /api/v1/devices/{device_uuid} deletes the device and returns a success message or 404 if the device does not exist.

## Checklist
- [x] Small, focused change
- [x] I tested it

Related Issue: #85 
