### PR TITLE
Add online/offline detection based on last_seen

### DIFF
--- a/services/src/services/device_service.py
+++ b/services/src/services/device_service.py
@@ -3,8 +3,23 @@ import uuid
 from services.src.firebase import device_store
 from services.src.schemas.device_schema import ConnectDeviceBody
 from fastapi import HTTPException
-from services.src.firebase import device_store
 from typing import Any, Dict
+
+
+OFFLINE_THRESHOLD_SECONDS = 30
+
+
+def is_device_online(device: dict) -> bool:
+    last_seen = device.get("last_seen")
+
+    if not last_seen:
+        return False
+
+    last_seen_dt = datetime.fromisoformat(last_seen)
+    now = datetime.now(timezone.utc)
+
+    diff = (now - last_seen_dt).total_seconds()
+    return diff <= OFFLINE_THRESHOLD_SECONDS
 
 
 def connect_device(payload: ConnectDeviceBody) -> Dict[str, Any]:
@@ -40,30 +55,39 @@ def connect_device(payload: ConnectDeviceBody) -> Dict[str, Any]:
 
 def list_devices(device_type: str | None = None):
     devices = device_store.list_devices()
+
     if device_type:
         devices = [d for d in devices if d.get("device_type") == device_type]
+
+    for device in devices:
+        device["is_online"] = is_device_online(device)
+
     return devices
 
-def get_device(device_uuid: str)-> Dict[str, Any]:
+
+def get_device(device_uuid: str) -> Dict[str, Any]:
     device = device_store.get_device(device_uuid)
 
     if not device:
         raise HTTPException(status_code=404, detail="Device not found")
 
+    device["is_online"] = is_device_online(device)
+
     return device
 
-def delete_device(device_uuid:str) -> dict[str, str]:
+
+def delete_device(device_uuid: str) -> dict[str, str]:
     device = device_store.delete_device(device_uuid)
 
     if not device:
         raise HTTPException(status_code=404, detail="Device not found")
-    
+
     return {
         "message": "Device deleted successfully",
         "device_uuid": device_uuid
     }
 
+
 def heartbeat(device_uuid: str):
     now = datetime.now(timezone.utc)
     return device_store.update_last_seen(device_uuid, now)
-


### PR DESCRIPTION
## Summary
This PR adds logic to determine whether a device is online or offline based on its `last_seen` timestamp.

The service layer is updated so that:
- devices are marked as online if they have been seen recently
- devices are marked as offline if they have not sent a heartbeat within a defined time threshold

## Why
This change implements task #31: "Mark device as offline".

It ensures that the system can reflect the real-time status of devices instead of only storing raw timestamps.

## Test
- Ran the backend locally using uvicorn
- Verified that `/api/v1/devices` endpoint works (returns 200 OK)
- Observed that the device list is currently empty locally, which prevents full end-to-end verification through the API
- Logic was verified at service level (based on `last_seen` timestamps)

## Checklist
- [x] Small, focused change
- [x] I tested it
- [x] Linked issue/requirement if relevant

Related Issue: #31