### PR TITLE
Replace post_command TODO with service handoff

### DIFF
--- a/services/src/controllers/device_controller.py
+++ b/services/src/controllers/device_controller.py
@@ -1,5 +1,5 @@
 from services.src.services import device_service
-from services.src.schemas.device_schema import ConnectDeviceBody
+from services.src.schemas.device_schema import ConnectDeviceBody, CommandPayload
 from services.src.utils.logger import get_logger
 
 logger = get_logger("device_controller")
@@ -12,29 +12,35 @@ logger = get_logger("device_controller")
 def list_devices(type: str | None = None):
     return device_service.list_devices(device_type=type)
 
+
 def connect_device(payload: ConnectDeviceBody):
     return device_service.connect_device(payload)
 
+
 def get_device(device_uuid: str):
     return device_service.get_device(device_uuid)
+
 
 def update_device(device_uuid: str):
     # TODO: return device_service.update_device(device_uuid, payload, user)
     return {"todo": "update_device service call", "device_uuid": device_uuid}
 
+
 def delete_device(device_uuid: str):
-    return device_service.delete_device(device_uuid)   
+    return device_service.delete_device(device_uuid)
+
 
 # -------------------------
 # Commands
 # -------------------------
 
-def post_command(device_uuid: str, command: str, params: dict = None):
-    return device_service.post_command(
+async def post_command(device_uuid: str, payload: CommandPayload):
+    return await device_service.post_command(
         device_uuid=device_uuid,
-        command=command,
-        params=params or {},
+        payload=payload,
     )
+
+
 # -------------------------
 # Bridge Integration
 # -------------------------
@@ -45,7 +51,6 @@ def handle_command_ack(device_uuid: str, status: str, reported_state: dict):
     Updates the device's reported state.
     """
     try:
-        # Update device with reported state
         logger.info(f"Updating device {device_uuid} with reported state: {reported_state}")
         # TODO: Implement state update in service layer
         return {"device_uuid": device_uuid, "status": status}
@@ -53,12 +58,14 @@ def handle_command_ack(device_uuid: str, status: str, reported_state: dict):
         logger.error(f"Failed to handle command ACK: {e}")
         raise
 
+
 # -------------------------
 # Health
 # -------------------------
 
 def heartbeat(device_uuid: str):
     return device_service.heartbeat(device_uuid)
+
 
 # -------------------------
 # Events (placeholder)

--- a/services/src/routes/device_routes.py
+++ b/services/src/routes/device_routes.py
@@ -30,8 +30,8 @@ def delete_device(device_uuid: str, user=Depends(optional_user)):
 # -------------------------
 
 @router.post("/{device_uuid}/commands")
-def post_command(device_uuid: str, payload: CommandPayload, user=Depends(optional_user)):
-    return controller.post_command(device_uuid, payload)
+async def post_command(device_uuid: str, payload: CommandPayload, user=Depends(optional_user)):
+    return await controller.post_command(device_uuid=device_uuid, payload=payload)
 
 # -------------------------
 # Health

--- a/services/src/services/device_service.py
+++ b/services/src/services/device_service.py
@@ -1,9 +1,10 @@
 from datetime import datetime, timezone
 import uuid
 from services.src.firebase import device_store
-from services.src.schemas.device_schema import ConnectDeviceBody
+from services.src.schemas.device_schema import ConnectDeviceBody, CommandPayload
 from fastapi import HTTPException
 from typing import Any, Dict
+from services.src.bridge.bridge import dispatch_command
 
 
 OFFLINE_THRESHOLD_SECONDS = 30
@@ -93,15 +94,23 @@ def heartbeat(device_uuid: str):
     return device_store.update_last_seen(device_uuid, now)
 
 
-def post_command(device_uuid: str, command: str, params: dict | None = None) -> Dict[str, Any]:
+async def post_command(device_uuid: str, payload: CommandPayload) -> Dict[str, Any]:
     device = device_store.get_device(device_uuid)
 
     if not device:
         raise HTTPException(status_code=404, detail="Device not found")
 
-    return {
-        "message": "Command handed off to service",
+    command_payload = {
+        "type": "COMMAND",
         "device_uuid": device_uuid,
-        "command": command,
-        "params": params or {},
+        "state": payload.state,
+    }
+
+    sent = await dispatch_command(command_payload)
+
+    return {
+        "message": "Command dispatched",
+        "device_uuid": device_uuid,
+        "sent": sent,
+        "payload": command_payload,
     }


### PR DESCRIPTION
## Summary
Replaced the placeholder TODO in post_command with a proper service handoff.

The controller now forwards incoming command requests to the device_service instead of returning a mock response.

## Why
Implements task #96 and aligns the controller with the current architecture (controller → service → store).

## Test
Ran the server locally using uvicorn and tested the endpoint with curl.

Verified that:
- Requests are passed from controller to service
- A structured response is returned
- Device existence is validated correctly

## Checklist
- [x] Small, focused change
- [x] I tested it
- [x] Linked issue/requirement if relevant

Related Issue: #96