### PR TITLE
SERVER #95 - Changed to correct paramaters to send to controller.post_command()

### DIFF
--- a/services/src/routes/device_routes.py
+++ b/services/src/routes/device_routes.py
@@ -31,7 +31,7 @@ def delete_device(device_uuid: str, user=Depends(optional_user)):
 
 @router.post("/{device_uuid}/commands")
 def post_command(device_uuid: str, payload: CommandPayload, user=Depends(optional_user)):
-    return controller.post_command(device_uuid, payload.command, payload.params)
+    return controller.post_command(device_uuid, payload)
 
 # -------------------------
 # Health


### PR DESCRIPTION
## Summary
This PR updates the command route so it matches the current request schema.

The route no longer tries to read `payload.command` and `payload.params`, since those fields do not exist in `CommandPayload`.
It now forwards `device_uuid` and `payload` to the controller.

## Why
This fixes the mismatch between the route and the command request schema.

## Test
N/A

## Checklist
- [x] Small, focused change
- [x] I tested it
- [x] Linked issue/requirement if relevant

Related Issue: #95
