### PR TITLE
SERVER Task 99 - Added dispatch function and supporting code

### DIFF
--- a/services/src/bridge/ble_controller.py
+++ b/services/src/bridge/ble_controller.py
@@ -6,6 +6,10 @@ from bleak import BleakClient, BleakScanner
 
 from services.src.utils.logger import get_logger
 from services.src.bridge.bridge_message_handler import handle_incoming_message
+from services.src.bridge.bridge_state import (
+    set_active_ble_client,
+    clear_active_ble_client,
+)
 from services.src.config.bridge_config import HM10_UUID, CMD_DELAY
 
 logger = get_logger("ble_controller")
@@ -59,6 +63,7 @@ def make_notification_handler(client: BleakClient):
 
 async def run_ble_session(client: BleakClient):
     logger.info("Connected via Bluetooth")
+    set_active_ble_client(client)
 
     handler = make_notification_handler(client)
     await client.start_notify(HM10_UUID, handler)
@@ -67,6 +72,7 @@ async def run_ble_session(client: BleakClient):
         while client.is_connected:
             await asyncio.sleep(1)
     finally:
+        clear_active_ble_client()
         logger.info("BLE session ended")
 
 
@@ -81,6 +87,7 @@ async def run_ble() -> bool:
     for device in devices:
         logger.info(f"Found BLE device: name={device.name}, address={device.address}")
 
+    # TODO: Maybe add some sort of identifier/detector of Arduino?
     target = next((device for device in devices if device.name), None)
 
     if not target:

--- a/services/src/bridge/bridge.py
+++ b/services/src/bridge/bridge.py
@@ -1,9 +1,14 @@
 import asyncio
 
 from services.src.utils.logger import get_logger
-from services.src.bridge.ble_controller import run_ble
-from services.src.bridge.usb_controller import run_usb
+from services.src.bridge.ble_controller import run_ble, send_ble_json
+from services.src.bridge.usb_controller import run_usb, send_usb_json
+from services.src.bridge.bridge_state import (
+    get_active_ble_client,
+    get_active_usb_serial,
+)
 from services.src.config.bridge_config import RECONNECT_DELAY
+
 
 logger = get_logger("bridge")
 
@@ -25,6 +30,20 @@ async def run_bridge():
         except Exception as e:
             logger.error(f"Bridge error: {e}")
             await asyncio.sleep(RECONNECT_DELAY)
+
+
+async def dispatch_command(payload: dict) -> bool:
+    """Send a command payload through the active BLE transport, or USB as fallback."""
+    ble_client = get_active_ble_client()
+    if ble_client is not None:
+        return await send_ble_json(ble_client, payload)
+    
+    usb_serial = get_active_usb_serial()
+    if usb_serial is not None:
+        return await send_usb_json(usb_serial, payload)
+    
+    logger.warning("No active BLE or USB transport available for command dispatch")
+    return False
 
 
 if __name__ == "__main__":

--- a/services/src/bridge/bridge_state.py
+++ b/services/src/bridge/bridge_state.py
@@ -1,0 +1,30 @@
+active_ble_client = None
+active_usb_serial = None
+
+
+def set_active_ble_client(client):
+    global active_ble_client
+    active_ble_client = client
+
+
+def clear_active_ble_client():
+    global active_ble_client
+    active_ble_client = None
+
+
+def get_active_ble_client():
+    return active_ble_client
+
+
+def set_active_usb_serial(ser):
+    global active_usb_serial
+    active_usb_serial = ser
+
+
+def clear_active_usb_serial():
+    global active_usb_serial
+    active_usb_serial = None
+
+
+def get_active_usb_serial():
+    return active_usb_serial

--- a/services/src/bridge/usb_controller.py
+++ b/services/src/bridge/usb_controller.py
@@ -5,6 +5,10 @@ import serial.tools.list_ports
 
 from services.src.utils.logger import get_logger
 from services.src.bridge.bridge_message_handler import handle_incoming_message
+from services.src.bridge.bridge_state import (
+    set_active_usb_serial,
+    clear_active_usb_serial,
+)
 from services.src.config.bridge_config import USB_BAUD, USB_PORT, CMD_DELAY
 
 logger = get_logger("usb_controller")
@@ -41,6 +45,7 @@ async def run_usb_session(port: str):
         return
 
     logger.info("Connected via USB Serial")
+    set_active_usb_serial(ser)
 
     buffer = ""
 
@@ -65,6 +70,7 @@ async def run_usb_session(port: str):
     except Exception as e:
         logger.error(f"USB session error: {e}")
     finally:
+        clear_active_usb_serial()
         if ser.is_open:
             ser.close()
         logger.info("USB session ended")


### PR DESCRIPTION
## Summary
This PR adds basic dispatch support for commands in `bridge.py` and related files.

The bridge can now:
- keep track of the active BLE connection
- keep track of the active USB serial connection
- send a command payload through BLE if available
- otherwise fall back to USB
- return `False` if no active transport is available

## Why
This is needed so the server bridge can dispatch a COMMAND payload to the currently active device.

## Test
Manually tested that `dispatch_command(...)` returns `False` and logs a warning when no active BLE or USB transport is available.

## Checklist
- [x] Small, focused change
- [x] I tested it
- [x] Linked issue/requirement if relevant

Related Issue: #99 