### PR TITLE
Added routing for REST Devices

### DIFF
--- a/services/src/controllers/device_controller.py
+++ b/services/src/controllers/device_controller.py
@@ -52,8 +52,11 @@ def handle_command_ack(device_uuid: str, status: str, reported_state: dict):
     """
     try:
         logger.info(f"Updating device {device_uuid} with reported state: {reported_state}")
-        # TODO: Implement state update in service layer
-        return {"device_uuid": device_uuid, "status": status}
+        return device_service.handle_command_ack(
+            device_uuid=device_uuid,
+            status=status,
+            reported_state=reported_state,
+        )
     except Exception as e:
         logger.error(f"Failed to handle command ACK: {e}")
         raise
@@ -65,6 +68,10 @@ def handle_command_ack(device_uuid: str, status: str, reported_state: dict):
 
 def heartbeat(device_uuid: str):
     return device_service.heartbeat(device_uuid)
+
+
+def get_next_command(device_uuid: str):
+    return device_service.get_next_command(device_uuid)
 
 
 # -------------------------

--- a/services/src/firebase/device_store.py
+++ b/services/src/firebase/device_store.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Optional
 
 # In-memory store (dev/test)
 _DEVICES: Dict[str, Dict[str, Any]] = {}
+_PENDING_COMMANDS: Dict[str, list[Dict[str, Any]]] = {}
 
 
 def get_device(device_uuid: str) -> Dict[str, Any] | None:
@@ -25,6 +26,7 @@ def register_device(device_uuid: str, data: Dict[str, Any]) -> Dict[str, Any]:
     }
 
     _DEVICES[device_uuid] = device
+    _PENDING_COMMANDS.setdefault(device_uuid, [])
     return device
 
 
@@ -46,6 +48,7 @@ def update_device(device_uuid: str, data: Dict[str, Any]) -> Dict[str, Any]:
     existing["status"] = existing_status
 
     existing["last_seen"] = data.get("last_seen") or datetime.now(timezone.utc).isoformat()
+    _PENDING_COMMANDS.setdefault(device_uuid, [])
 
     return existing
 
@@ -54,6 +57,7 @@ def list_devices() -> list[Dict[str, Any]]:
     return list(_DEVICES.values())
 
 def delete_device(device_uuid: str)-> Dict[str, Any] | None: 
+    _PENDING_COMMANDS.pop(device_uuid, None)
     return _DEVICES.pop(device_uuid, None)
 
 def update_last_seen(device_uuid: str, timestamp: datetime) -> Dict[str, Any]:
@@ -63,3 +67,32 @@ def update_last_seen(device_uuid: str, timestamp: datetime) -> Dict[str, Any]:
 
     device["last_seen"] = timestamp.isoformat()
     return device
+
+
+def update_device_state(device_uuid: str, reported_state: Dict[str, Any], status: Optional[Dict[str, Any]] = None) -> Dict[str, Any] | None:
+    device = _DEVICES.get(device_uuid)
+    if not device:
+        return None
+
+    current_state = device.get("state", {})
+    current_state.update(reported_state)
+    device["state"] = current_state
+
+    current_status = device.get("status", {})
+    if status:
+        current_status.update(status)
+    current_status["connected"] = True
+    device["status"] = current_status
+    device["last_seen"] = datetime.now(timezone.utc).isoformat()
+    return device
+
+
+def enqueue_command(device_uuid: str, payload: Dict[str, Any]) -> None:
+    _PENDING_COMMANDS.setdefault(device_uuid, []).append(payload)
+
+
+def pop_next_command(device_uuid: str) -> Dict[str, Any] | None:
+    queue = _PENDING_COMMANDS.setdefault(device_uuid, [])
+    if not queue:
+        return None
+    return queue.pop(0)

--- a/services/src/main.py
+++ b/services/src/main.py
@@ -2,6 +2,7 @@ import asyncio
 from fastapi import FastAPI
 from services.src.middleware.logging_middleware import logging_middleware
 from services.src.routes.device_routes import router as device_router
+from services.src.routes.device_gateway_routes import router as device_gateway_router
 from services.src.routes.state_routes import router as state_router
 from services.src.utils.logger import get_logger
 from services.src.bridge.bridge import run_bridge
@@ -51,6 +52,7 @@ async def shutdown_event():
 
 # Include routers
 app.include_router(device_router, prefix="/api/v1")
+app.include_router(device_gateway_router, prefix="/api/v1")
 app.include_router(state_router, prefix="/api/v1")
 
 @app.get("/")

--- a/services/src/middleware/logging_middleware.py
+++ b/services/src/middleware/logging_middleware.py
@@ -3,6 +3,10 @@ from fastapi import Request
 from services.src.utils.logger import get_logger
 
 logger = get_logger("middleware")
+QUIET_PATH_SUFFIXES = {
+    "/commands/next",
+    "/heartbeat",
+}
 
 async def logging_middleware(request: Request, call_next):
     start_time = time.time()
@@ -10,6 +14,15 @@ async def logging_middleware(request: Request, call_next):
     response = await call_next(request)
 
     duration_ms = (time.time() - start_time) * 1000
+    path = request.url.path
+
+    if any(path.endswith(suffix) for suffix in QUIET_PATH_SUFFIXES):
+        logger.debug(
+            f"{request.method} {request.url} "
+            f"-> {response.status_code} "
+            f"({duration_ms:.2f} ms)"
+        )
+        return response
 
     logger.info(
         f"{request.method} {request.url} "

--- a/services/src/routes/device_gateway_routes.py
+++ b/services/src/routes/device_gateway_routes.py
@@ -1,0 +1,34 @@
+from fastapi import APIRouter
+
+from services.src.controllers import device_controller as controller
+from services.src.schemas.device_schema import ConnectDeviceBody, CommandAckPayload
+
+
+router = APIRouter(
+    prefix="/device-gateway",
+    tags=["device-gateway"],
+)
+
+
+@router.post("/connect")
+def connect_device(payload: ConnectDeviceBody):
+    return controller.connect_device(payload)
+
+
+@router.post("/{device_uuid}/heartbeat")
+def heartbeat(device_uuid: str):
+    return controller.heartbeat(device_uuid=device_uuid)
+
+
+@router.get("/{device_uuid}/commands/next")
+def get_next_command(device_uuid: str):
+    return controller.get_next_command(device_uuid=device_uuid)
+
+
+@router.post("/{device_uuid}/command-ack")
+def post_command_ack(device_uuid: str, payload: CommandAckPayload):
+    return controller.handle_command_ack(
+        device_uuid=device_uuid,
+        status=payload.status,
+        reported_state=payload.reported_state,
+    )

--- a/services/src/schemas/device_schema.py
+++ b/services/src/schemas/device_schema.py
@@ -19,3 +19,8 @@ class ConnectDeviceBody(BaseModel):
 
 class CommandPayload(BaseModel):
     state: Dict[str, Any]
+
+
+class CommandAckPayload(BaseModel):
+    status: str = "ok"
+    reported_state: Dict[str, Any] = Field(default_factory=dict)

--- a/services/src/services/device_service.py
+++ b/services/src/services/device_service.py
@@ -94,6 +94,36 @@ def heartbeat(device_uuid: str):
     return device_store.update_last_seen(device_uuid, now)
 
 
+def get_next_command(device_uuid: str) -> Dict[str, Any]:
+    device = device_store.get_device(device_uuid)
+    if not device:
+        raise HTTPException(status_code=404, detail="Device not found")
+
+    command = device_store.pop_next_command(device_uuid)
+    return {
+        "device_uuid": device_uuid,
+        "command": command,
+    }
+
+
+def handle_command_ack(device_uuid: str, status: str, reported_state: Dict[str, Any]) -> Dict[str, Any]:
+    device = device_store.update_device_state(
+        device_uuid,
+        reported_state,
+        status={"last_command_status": status},
+    )
+
+    if not device:
+        raise HTTPException(status_code=404, detail="Device not found")
+
+    return {
+        "message": "Command acknowledgement received",
+        "device_uuid": device_uuid,
+        "status": status,
+        "reported_state": reported_state,
+    }
+
+
 async def post_command(device_uuid: str, payload: CommandPayload) -> Dict[str, Any]:
     device = device_store.get_device(device_uuid)
 
@@ -106,11 +136,22 @@ async def post_command(device_uuid: str, payload: CommandPayload) -> Dict[str, A
         "state": payload.state,
     }
 
-    sent = await dispatch_command(command_payload)
+    transport = device.get("transport", {})
+    transport_mode = transport.get("mode")
+    transport_protocol = transport.get("protocol")
+
+    if transport_mode == "rest" or transport_protocol == "rest":
+        device_store.enqueue_command(device_uuid, command_payload)
+        sent = True
+        delivery = "queued"
+    else:
+        sent = await dispatch_command(command_payload)
+        delivery = "bridge"
 
     return {
         "message": "Command dispatched",
         "device_uuid": device_uuid,
         "sent": sent,
+        "delivery": delivery,
         "payload": command_payload,
     }


### PR DESCRIPTION
## Summary
Adds a minimal REST device gateway for non-bridge devices.

This PR adds support for:
- REST device registration
- heartbeat updates
- command polling
- command acknowledgements
- queued command delivery for REST devices

The existing Unit-facing routes remain unchanged.

## Why
The server already supports bridge-based devices such as the Arduino house, but it did not support a proper REST-based `Device -> Server` flow for simulated or external devices such as the RVC.

This PR adds a minimal solution so REST devices can behave like real devices in the system without changing the existing Unit API.

## Test
Verified locally by testing this flow:
1. REST device connects to server
2. Unit sends command through existing `/api/v1/devices/{device_uuid}/commands`
3. Command is queued for REST delivery
4. Device fetches command via `/api/v1/device-gateway/{device_uuid}/commands/next`
5. Device sends `command-ack`
6. Device state is updated and visible through `GET /api/v1/devices`

## Checklist
- [x] Small, focused change
- [x] I tested it
- [x] Linked issue/requirement if relevant

Related Issue: #139 