### PR TITLE
Added dependency to validate tokens in routes

### DIFF
--- a/services/src/dependencies/auth.py
+++ b/services/src/dependencies/auth.py
@@ -1,5 +1,33 @@
-from fastapi import Header
+from fastapi import Header, HTTPException
+from services.src.utils.security import decode_token, verify_access_token
+
 
 # If the param is func, it will be mandatory, so we set default to None to make it optional until authentication is implemented
 def optional_user(authorization: str | None = Header(default=None)):
     return None
+
+"""
+Accessing current user:
+
+- Expects and validates the current user from Authorization header.
+- Decodes and verifies the token.
+- Raises 401 if the token is missing, invalid or incorrectly formatted.
+
+Returns the user ID (sub).
+"""
+
+def current_user(authorization: str = Header(...))-> str:
+    try:
+        # scheme = "Bearer ", token = "abc123"
+        scheme, token = authorization.split()
+
+        # Checks auth-type
+        if scheme.lower() != "bearer":
+            raise HTTPException(status_code=401, detail="Invalid auth scheme")
+        
+        payload = decode_token(token) # Token is decoded
+        verify_access_token(payload) # Is the token valid?
+
+        return payload["sub"]
+    except Exception:
+        raise HTTPException(status_code=401, detail="Invalid or missing token")


### PR DESCRIPTION
## Summary
This PR adds an `auth.py` file that provides a dependency for validating access tokens.
It will be used in routes via dependency injection.

## Why
To keep authentication logic modular and separate from route handlers.
Routes should not handle token validation directly.

## Checklist
- [x] Small, focused change

Related Issue: #108
