### PR TITLE
Heartbeat now sets connected to true as well

### DIFF
--- a/services/src/firebase/device_store.py
+++ b/services/src/firebase/device_store.py
@@ -84,6 +84,9 @@ def update_last_seen(device_uuid: str, timestamp: datetime) -> Dict[str, Any]:
         return {"error": "device not found", "device_uuid": device_uuid}
 
     device["last_seen"] = timestamp.isoformat()
+    status = device.get("status", {})
+    status["connected"] = True
+    device["status"] = status
     _device_ref(device_uuid).set(device)
     return device
 


### PR DESCRIPTION
## Summary
This PR updates the heartbeat flow so that a device is marked as connected again when it starts sending heartbeats after previously being marked offline.

Specifically, `update_last_seen()` now restores `status.connected = true` in addition to updating the `last_seen` timestamp.

## Why
This fixes a bug where stale devices could be marked offline correctly, but would remain stored as offline even after becoming active again and sending new heartbeats.

## Test
Tested with test-script, where simulated RVCs heartbeat actually updates `connected = true` in the database.

## Checklist
- [x] Small, focused change
- [x] I tested it
- [x] Linked issue/requirement if relevant

Related Issue: #155
