### PR TITLE
App works with and without backend, allowing full demo and testing

### DIFF
--- a/apps/mobile/app/build.gradle.kts
+++ b/apps/mobile/app/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.navigation.compose)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/apps/mobile/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -10,6 +12,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:usesCleartextTraffic="true"
         android:theme="@style/Theme.Mobile">
         <activity
             android:name=".MainActivity"

--- a/apps/mobile/app/src/main/java/com/interactivehouse/mobile/MainActivity.kt
+++ b/apps/mobile/app/src/main/java/com/interactivehouse/mobile/MainActivity.kt
@@ -4,31 +4,19 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
-import com.interactivehouse.mobile.ui.screens.DeviceListScreen
-import com.interactivehouse.mobile.ui.screens.LoginScreen
+import com.interactivehouse.mobile.ui.navigation.AppNavHost
 import com.interactivehouse.mobile.ui.theme.MobileTheme
 
-
+/**
+ * Entry activity. Compose UI must be built inside [setContent] so @Composable calls are valid.
+ */
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
-
-        var showDeviceList by mutableStateOf(false)
-
         setContent {
             MobileTheme {
-                if (showDeviceList) {
-                    DeviceListScreen()
-                } else {
-                    LoginScreen(
-                        onLogin = { _, _ -> showDeviceList = true },
-                        onGoToSignup = { }
-                    )
-                }
+                AppNavHost()
             }
         }
     }

--- a/apps/mobile/app/src/main/java/com/interactivehouse/mobile/data/api/DeviceApi.kt
+++ b/apps/mobile/app/src/main/java/com/interactivehouse/mobile/data/api/DeviceApi.kt
@@ -1,16 +1,64 @@
 package com.interactivehouse.mobile.data.api
 
 import com.interactivehouse.mobile.data.model.Device
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.POST
 import retrofit2.http.Path
 
+/**
+ * This interface defines all HTTP calls related to devices.
+ * Retrofit uses this to generate the actual network code.
+ */
 interface DeviceApi {
+    //Fetches all devices from the server.
     // To return a list of devices
     @GET("devices")
     suspend fun getDevices(): List<Device>
 
+    // * Fetch a single device by its UUID.
     @GET("devices/{uuid}")
     suspend fun getDevice(
-        @Path("uuid") uuid: String
+        @Path("uuid") uuid: String // replaces {uuid} in the URL
     ): Device
+
+    /* Sends a command to a device.
+    //     * The body must follow this format:
+        {
+          "state": {
+          "power": true,
+          "brightness": 50
+           }
+        }
+    */
+    @POST("devices/{uuid}/commands")
+    suspend fun sendCommand(
+        @Path("uuid") uuid: String,
+        @Body body: StateCommandRequest
+    ): StateCommandResponse
+
+    /**
+     * Command request/response for writable capabilities (boolean, integer, etc.).
+     *
+     * API contract:
+     * POST /api/v1/devices/{device_uuid}/commands
+     * body: { "state": { "<key>": <value>, ... } }
+     */
+    data class StateCommandRequest(
+        val state: Map<String, @JvmSuppressWildcards Any>
+    )
+
+    /**
+     * Example success:
+     * { "status": "success", "state": { "power": true } }
+     *
+     * Example error:
+     * { "status": "error", "error": "invalid_state", "message": "one or more state values are invalid" }
+     */
+    data class StateCommandResponse(
+        val status: String,
+        val state: Map<String, @JvmSuppressWildcards Any>? = null,
+        val error: String? = null,
+        val message: String? = null
+    )
 }

--- a/apps/mobile/app/src/main/java/com/interactivehouse/mobile/data/api/RetrofitClient.kt
+++ b/apps/mobile/app/src/main/java/com/interactivehouse/mobile/data/api/RetrofitClient.kt
@@ -4,11 +4,16 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import kotlin.jvm.java
+import kotlin.getValue
 
 object RetrofitClient {
 
-    private const val BASE_URL = "http://10.0.2.2:8080/" //server address
+    // Use local when you run the backend on your machine:
+    // private const val BASE_URL = "http://10.0.2.2:8000/api/v1/"
 
+    // Use ngrok  when the backend has been started:
+    private const val BASE_URL = "https://knolly-svetlana-beribboned.ngrok-free.dev/api/v1/" //server address
     // Print every network request and response in Android log
     private val loggingInterceptor = HttpLoggingInterceptor().apply {
         level = HttpLoggingInterceptor.Level.BODY
@@ -18,11 +23,13 @@ object RetrofitClient {
         .addInterceptor(loggingInterceptor)
         .build()
 
-    val retrofit: Retrofit = Retrofit.Builder()
+    private val retrofit: Retrofit = Retrofit.Builder()
         .baseUrl(BASE_URL)
         .client(httpClient)
         .addConverterFactory(GsonConverterFactory.create()) // To convert JSON to kotlin objects automatically
         .build()
     //connect retrofit to Device Api
-    val deviceApi: DeviceApi = retrofit.create(DeviceApi::class.java)
+    val deviceApi: DeviceApi by lazy {
+        retrofit.create(DeviceApi::class.java)
+    }
 }

--- a/apps/mobile/app/src/main/java/com/interactivehouse/mobile/data/mock/DemoDeviceStore.kt
+++ b/apps/mobile/app/src/main/java/com/interactivehouse/mobile/data/mock/DemoDeviceStore.kt
@@ -1,0 +1,124 @@
+package com.interactivehouse.mobile.data.mock
+
+import com.interactivehouse.mobile.data.api.DeviceApi
+import com.interactivehouse.mobile.data.model.CapabilitySpec
+import com.interactivehouse.mobile.data.model.Device
+import kotlin.collections.iterator
+
+/**
+ * In-memory device list and command handling for demo mode.
+ * Thread-safe for coroutine access from the repository.
+ */
+object DemoDeviceStore {
+
+    private val lock = Any()
+    private val devices: MutableList<Device> =
+        FakeDevices.seedDevices().map { it.copyForMutation() }.toMutableList()
+
+    fun snapshot(): List<Device> = synchronized(lock) {
+        devices.map { it.copyForMutation() }
+    }
+
+    fun getDevice(uuid: String): Device? = synchronized(lock) {
+        devices.find { it.deviceUuid == uuid }?.copyForMutation()
+    }
+
+    /**
+     * Validates [patch] keys against writable capabilities, merges into local state,
+     * and returns a response in the same shape as the real API.
+     */
+    fun applyStatePatch(uuid: String, patch: Map<String, Any>): DeviceApi.StateCommandResponse {
+        if (patch.isEmpty()) {
+            return DeviceApi.StateCommandResponse(
+                status = "error",
+                error = "invalid_state",
+                message = "empty state patch"
+            )
+        }
+        synchronized(lock) {
+            val index = devices.indexOfFirst { it.deviceUuid == uuid }
+            if (index < 0) {
+                return DeviceApi.StateCommandResponse(
+                    status = "error",
+                    error = "not_found",
+                    message = "Device not found"
+                )
+            }
+            val device = devices[index]
+            for ((key, raw) in patch) {
+                val spec = device.capabilities[key]
+                    ?: return DeviceApi.StateCommandResponse(
+                        status = "error",
+                        error = "unknown_capability",
+                        message = "Unknown capability: $key"
+                    )
+                if (!spec.writable) {
+                    return DeviceApi.StateCommandResponse(
+                        status = "error",
+                        error = "read_only",
+                        message = "Capability is not writable: $key"
+                    )
+                }
+                val coerced = coerceValue(raw, spec)
+                    ?: return DeviceApi.StateCommandResponse(
+                        status = "error",
+                        error = "invalid_state",
+                        message = "Invalid value for $key"
+                    )
+                if (!validateRange(coerced, spec)) {
+                    return DeviceApi.StateCommandResponse(
+                        status = "error",
+                        error = "invalid_state",
+                        message = "Value out of range for $key"
+                    )
+                }
+            }
+            val newState = LinkedHashMap<String, Any>(device.state)
+            for ((key, raw) in patch) {
+                val spec = device.capabilities.getValue(key)
+                newState[key] = coerceValue(raw, spec)!!
+            }
+            val updated = device.copy(state = newState)
+            devices[index] = updated
+            val responseState = LinkedHashMap<String, Any>()
+            for (key in patch.keys) {
+                responseState[key] = newState[key]!!
+            }
+            return DeviceApi.StateCommandResponse(
+                status = "success",
+                state = responseState
+            )
+        }
+    }
+
+    private fun coerceValue(raw: Any, spec: CapabilitySpec): Any? {
+        return when (spec.type) {
+            "boolean" -> when (raw) {
+                is Boolean -> raw
+                else -> null
+            }
+            "integer" -> when (raw) {
+                is Int -> raw
+                is Number -> raw.toInt()
+                else -> null
+            }
+            else -> null
+        }
+    }
+
+    private fun validateRange(value: Any, spec: CapabilitySpec): Boolean {
+        if (spec.type != "integer") return true
+        val v = (value as? Number)?.toInt() ?: return false
+        val min = spec.min
+        val max = spec.max
+        if (min != null && v < min) return false
+        if (max != null && v > max) return false
+        return true
+    }
+
+    private fun Device.copyForMutation(): Device =
+        copy(
+            capabilities = LinkedHashMap(capabilities),
+            state = LinkedHashMap(state)
+        )
+}

--- a/apps/mobile/app/src/main/java/com/interactivehouse/mobile/data/mock/FakeDevices.kt
+++ b/apps/mobile/app/src/main/java/com/interactivehouse/mobile/data/mock/FakeDevices.kt
@@ -1,0 +1,42 @@
+package com.interactivehouse.mobile.data.mock
+
+import com.interactivehouse.mobile.data.model.CapabilitySpec
+import com.interactivehouse.mobile.data.model.Device
+
+/**
+ * Seed data matching the /api/v1 devices contract (capabilities + state).
+ */
+object FakeDevices {
+
+    fun seedDevices(): List<Device> = listOf(demoLight(), demoFan())
+
+    private fun demoLight(): Device = Device(
+        deviceUuid = "demo-light-001",
+        name = "Living Room Lamp",
+        room = "Living Room",
+        type = "light",
+        capabilities = mapOf(
+            "power" to CapabilitySpec(type = "boolean", writable = true),
+            "brightness" to CapabilitySpec(type = "integer", writable = true, min = 0, max = 100)
+        ),
+        state = mapOf(
+            "power" to false,
+            "brightness" to 50
+        )
+    )
+
+    private fun demoFan(): Device = Device(
+        deviceUuid = "demo-fan-001",
+        name = "Bedroom Fan",
+        room = "Bedroom",
+        type = "fan",
+        capabilities = mapOf(
+            "power" to CapabilitySpec(type = "boolean", writable = true),
+            "speed" to CapabilitySpec(type = "integer", writable = true, min = 0, max = 3)
+        ),
+        state = mapOf(
+            "power" to true,
+            "speed" to 1
+        )
+    )
+}

--- a/apps/mobile/app/src/main/java/com/interactivehouse/mobile/data/model/Device.kt
+++ b/apps/mobile/app/src/main/java/com/interactivehouse/mobile/data/model/Device.kt
@@ -1,19 +1,27 @@
 package com.interactivehouse.mobile.data.model
 
+import com.google.gson.annotations.SerializedName
+
 /**
  * Represents a smart device from the backend API.
  * Capabilities are optional; the API may include them for lights, sensors, etc.
  */
 data class Device(
+    @SerializedName("device_uuid")
     val deviceUuid: String,
+    val name: String?,
+    val room: String?,
     val type: String,
-    val capabilities: Map<String, CapabilitySpec>? = null
+    val capabilities: Map<String, CapabilitySpec>,
+    val state: Map<String, Any>
 )
 
 /**
  * Describes a device capability (e.g. "power": { "type": "boolean", "writable": true }).
  */
 data class CapabilitySpec(
-    val type: String? = null,
-    val writable: Boolean? = null
+    val type: String,
+    val writable: Boolean,
+    val min: Int? = null,
+    val max: Int? = null
 )

--- a/apps/mobile/app/src/main/java/com/interactivehouse/mobile/data/repository/DeviceRepository.kt
+++ b/apps/mobile/app/src/main/java/com/interactivehouse/mobile/data/repository/DeviceRepository.kt
@@ -1,15 +1,59 @@
 package com.interactivehouse.mobile.data.repository
 
+import com.interactivehouse.mobile.data.DemoModeConfig
+import com.interactivehouse.mobile.data.api.DeviceApi
 import com.interactivehouse.mobile.data.api.RetrofitClient
+import com.interactivehouse.mobile.data.mock.DemoDeviceStore
 import com.interactivehouse.mobile.data.model.Device
 
-//wrap API calls, repository is the single place reponsible for data
-class DeviceRepository {
+/*
+* Repository for interacting with the device API.*/
+class DeviceRepository(
+    private val api: DeviceApi = RetrofitClient.deviceApi,
+    private val demoStore: DemoDeviceStore = DemoDeviceStore
+) {
+
+    /**
+     * Fetches all devices from the API/server.
+     * Calls:
+     * GET /api/v1/devices
+     */
     suspend fun getDevices(): List<Device> {
-        return RetrofitClient.deviceApi.getDevices()
+        return if (DemoModeConfig.USE_DEMO_MODE) {
+            demoStore.snapshot()
+        } else {
+            api.getDevices()
+        }
     }
 
+    //Fetch a single device by UUID
     suspend fun getDevice(uuid: String): Device {
-        return RetrofitClient.deviceApi.getDevice(uuid)
+        return if (DemoModeConfig.USE_DEMO_MODE) {
+            demoStore.getDevice(uuid)
+                ?: throw NoSuchElementException("Device not found: $uuid")
+        } else {
+            api.getDevice(uuid)
+        }
+    }
+
+    // send a command to a device
+    /* @param uuid Device ID (e.g. "light-1")
+     * @param state State payload for the command (partial state map)
+     *
+     * Calls:
+     * POST /api/v1/devices/{uuid}/commands
+     */
+    suspend fun sendCommand(
+        uuid: String,
+        state: Map<String, Any>
+    ): DeviceApi.StateCommandResponse {
+        return if (DemoModeConfig.USE_DEMO_MODE) {
+            demoStore.applyStatePatch(uuid, state)
+        } else {
+            api.sendCommand(
+                uuid,
+                DeviceApi.StateCommandRequest(state)
+            )
+        }
     }
 }

--- a/apps/mobile/app/src/main/java/com/interactivehouse/mobile/data/session/DemoModeConfig.kt
+++ b/apps/mobile/app/src/main/java/com/interactivehouse/mobile/data/session/DemoModeConfig.kt
@@ -1,0 +1,10 @@
+package com.interactivehouse.mobile.data
+
+/**
+ * When true, [com.interactivehouse.mobile.data.repository.DeviceRepository] serves fake devices
+ * and applies commands in memory. Set to false to use the real Retrofit backend.
+ */
+object DemoModeConfig {
+    //const val USE_DEMO_MODE: Boolean = true
+    const val USE_DEMO_MODE: Boolean = false
+}

--- a/apps/mobile/app/src/main/java/com/interactivehouse/mobile/ui/device/DeviceCapabilityControls.kt
+++ b/apps/mobile/app/src/main/java/com/interactivehouse/mobile/ui/device/DeviceCapabilityControls.kt
@@ -1,0 +1,138 @@
+package com.interactivehouse.mobile.ui.device
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.interactivehouse.mobile.data.model.CapabilitySpec
+import com.interactivehouse.mobile.data.model.Device
+import kotlin.math.roundToInt
+
+/**
+ * Capability-driven controls for a single device (detail screen).
+ */
+@Composable
+fun DeviceCapabilityControls(
+    device: Device,
+    isCommandInFlight: Boolean,
+    onBooleanCapability: (String, Boolean) -> Unit,
+    onIntegerCapability: (String, Int) -> Unit
+) {
+    val writableCaps = device.capabilities.entries
+        .filter { it.value.writable }
+        .sortedBy { it.key }
+    if (writableCaps.isEmpty()) {
+        Text(
+            text = "No writable capabilities",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        return
+    }
+    writableCaps.forEach { (key, spec) ->
+        CapabilityControlRow(
+            device = device,
+            capabilityKey = key,
+            spec = spec,
+            isCommandInFlight = isCommandInFlight,
+            onBooleanCapability = onBooleanCapability,
+            onIntegerCapability = onIntegerCapability
+        )
+    }
+}
+
+@Composable
+private fun CapabilityControlRow(
+    device: Device,
+    capabilityKey: String,
+    spec: CapabilitySpec,
+    isCommandInFlight: Boolean,
+    onBooleanCapability: (String, Boolean) -> Unit,
+    onIntegerCapability: (String, Int) -> Unit
+) {
+    when (spec.type) {
+        "boolean" -> {
+            val current = (device.state[capabilityKey] as? Boolean) ?: false
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(top = 12.dp)
+            ) {
+                Text(
+                    text = capabilityKey.replaceFirstChar { it.uppercase() },
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier.width(112.dp)
+                )
+                Switch(
+                    checked = current,
+                    onCheckedChange = { onBooleanCapability(capabilityKey, it) },
+                    enabled = !isCommandInFlight
+                )
+            }
+        }
+        "integer" -> {
+            val min = spec.min ?: 0
+            val max = spec.max ?: 100
+            val fallback = ((min + max) / 2).coerceIn(min, max)
+            val current = device.state[capabilityKey].toUiInt(fallback, min, max)
+            Column(modifier = Modifier.padding(top = 12.dp)) {
+                Text(
+                    text = "${capabilityKey.replaceFirstChar { it.uppercase() }} — $current",
+                    style = MaterialTheme.typography.bodyLarge
+                )
+                Slider(
+                    value = current.toFloat(),
+                    onValueChange = { raw ->
+                        val rounded = raw.roundToInt().coerceIn(min, max)
+                        onIntegerCapability(capabilityKey, rounded)
+                    },
+                    valueRange = min.toFloat()..max.toFloat(),
+                    steps = sliderSteps(min, max),
+                    enabled = !isCommandInFlight,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        }
+        else -> {
+            Text(
+                text = "$capabilityKey (${spec.type}) — unsupported control type",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 12.dp)
+            )
+        }
+    }
+}
+
+fun formatStateValue(value: Any?): String = when (value) {
+    null -> "—"
+    is Boolean -> if (value) "on" else "off"
+    is Number -> value.toInt().toString()
+    else -> value.toString()
+}
+
+fun sliderSteps(min: Int, max: Int): Int {
+    val span = max - min
+    return if (span in 1..10) span else 0
+}
+
+fun Any?.toUiInt(fallback: Int, min: Int, max: Int): Int {
+    val n = when (this) {
+        is Int -> this
+        is Double -> this.toInt()
+        is Float -> this.toInt()
+        is Number -> this.toInt()
+        else -> null
+    } ?: return fallback
+    return n.coerceIn(min, max)
+}
+
+

--- a/apps/mobile/app/src/main/java/com/interactivehouse/mobile/ui/navigation/AppNavHost.kt
+++ b/apps/mobile/app/src/main/java/com/interactivehouse/mobile/ui/navigation/AppNavHost.kt
@@ -1,0 +1,100 @@
+package com.interactivehouse.mobile.ui.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavHostController
+import androidx.navigation.NavType
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.navigation
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
+import com.interactivehouse.mobile.ui.screens.DeviceDetailScreen
+import com.interactivehouse.mobile.ui.screens.DeviceListScreen
+import com.interactivehouse.mobile.ui.screens.LoginScreen
+import com.interactivehouse.mobile.ui.screens.SignupPlaceholderScreen
+import com.interactivehouse.mobile.viewmodel.DeviceListViewModel
+
+object NavRoutes {
+    const val Login = "login"
+    const val SignupPlaceholder = "signup_placeholder"
+    const val DevicesGraph = "devices_graph"
+    const val DeviceList = "device_list"
+    const val DeviceDetail = "device_detail"
+    const val DeviceDetailPattern = "device_detail/{uuid}"
+}
+
+@Composable
+fun AppNavHost(
+    modifier: Modifier = Modifier,
+    navController: NavHostController = rememberNavController()
+) {
+    NavHost(
+        navController = navController,
+        startDestination = NavRoutes.Login,
+        modifier = modifier
+    ) {
+        composable(NavRoutes.Login) {
+            LoginScreen(
+                onLogin = { _, _ ->
+                    // Navigation-only hook: LoginScreen already validated non-blank fields.
+                    // Teammate-owned auth can later gate this navigate call without changing LoginScreen UI.
+                    navController.navigate(NavRoutes.DevicesGraph) {
+                        popUpTo(NavRoutes.Login) { inclusive = true }
+                    }
+                },
+                onGoToSignup = {
+                    navController.navigate(NavRoutes.SignupPlaceholder)
+                }
+            )
+        }
+        composable(NavRoutes.SignupPlaceholder) {
+            SignupPlaceholderScreen(onBack = { navController.popBackStack() })
+        }
+        navigation(
+            route = NavRoutes.DevicesGraph,
+            startDestination = NavRoutes.DeviceList
+        ) {
+            composable(NavRoutes.DeviceList) { entry ->
+                val graphEntry = remember(entry) {
+                    navController.getBackStackEntry(NavRoutes.DevicesGraph)
+                }
+                val vm: DeviceListViewModel = viewModel(graphEntry)
+                LaunchedEffect(Unit) {
+                    vm.loadDevices(showLoading = true)
+                    vm.startPeriodicRefresh()
+                }
+                DeviceListScreen(
+                    viewModel = vm,
+                    onDeviceClick = { device ->
+                        navController.navigate("${NavRoutes.DeviceDetail}/${device.deviceUuid}")
+                    }
+                )
+            }
+            composable(
+                route = NavRoutes.DeviceDetailPattern,
+                arguments = listOf(
+                    navArgument("uuid") { type = NavType.StringType }
+                )
+            ) { entry ->
+                val graphEntry = remember(entry) {
+                    navController.getBackStackEntry(NavRoutes.DevicesGraph)
+                }
+                val vm: DeviceListViewModel = viewModel(graphEntry)
+                val uuid = entry.arguments?.getString("uuid").orEmpty()
+                LaunchedEffect(Unit) {
+                    vm.startPeriodicRefresh()
+                }
+                DeviceDetailScreen(
+                    deviceUuid = uuid,
+                    viewModel = vm,
+                    onBack = { navController.popBackStack() }
+                )
+            }
+        }
+    }
+}
+

--- a/apps/mobile/app/src/main/java/com/interactivehouse/mobile/ui/screens/DeviceDetailScreen.kt
+++ b/apps/mobile/app/src/main/java/com/interactivehouse/mobile/ui/screens/DeviceDetailScreen.kt
@@ -1,0 +1,162 @@
+package com.interactivehouse.mobile.ui.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.interactivehouse.mobile.data.DemoModeConfig
+import com.interactivehouse.mobile.ui.device.DeviceCapabilityControls
+import com.interactivehouse.mobile.ui.device.formatStateValue
+import com.interactivehouse.mobile.viewmodel.DeviceListViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DeviceDetailScreen(
+    deviceUuid: String,
+    viewModel: DeviceListViewModel,
+    onBack: () -> Unit
+) {
+    val devices by viewModel.devices.collectAsState()
+    val errorMessage by viewModel.errorMessage.collectAsState()
+    val commandSuccessMessage by viewModel.commandSuccessMessage.collectAsState()
+    val commandErrorMessage by viewModel.commandErrorMessage.collectAsState()
+    val isCommandInFlight by viewModel.isCommandInFlight.collectAsState()
+
+    val device = devices.find { it.deviceUuid == deviceUuid }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = device?.let { d ->
+                            d.name?.takeIf { it.isNotBlank() }
+                                ?: d.type.replaceFirstChar { it.uppercase() }
+                        } ?: "Device"
+                    )
+                },
+                navigationIcon = {
+                    TextButton(onClick = onBack) {
+                        Text("Back")
+                    }
+                }
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(horizontal = 20.dp, vertical = 16.dp)
+        ) {
+            if (DemoModeConfig.USE_DEMO_MODE) {
+                Text(
+                    text = "DEMO MODE — local state only",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.tertiary,
+                    modifier = Modifier.padding(bottom = 12.dp)
+                )
+            }
+
+            errorMessage?.let { msg ->
+                Card(
+                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer),
+                    modifier = Modifier.padding(bottom = 8.dp)
+                ) {
+                    Text(msg, Modifier.padding(12.dp), color = MaterialTheme.colorScheme.onErrorContainer)
+                }
+            }
+            commandSuccessMessage?.let { msg ->
+                Card(
+                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
+                    modifier = Modifier.padding(bottom = 8.dp)
+                ) {
+                    Text(msg, Modifier.padding(12.dp), color = MaterialTheme.colorScheme.onPrimaryContainer)
+                }
+            }
+            commandErrorMessage?.let { msg ->
+                Card(
+                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer),
+                    modifier = Modifier.padding(bottom = 8.dp)
+                ) {
+                    Text(msg, Modifier.padding(12.dp), color = MaterialTheme.colorScheme.onErrorContainer)
+                }
+            }
+
+            if (device == null) {
+                Text(
+                    text = "Device not found or still loading.",
+                    style = MaterialTheme.typography.bodyLarge
+                )
+                return@Column
+            }
+
+            Text(
+                text = "Room: ${device.room?.takeIf { it.isNotBlank() } ?: "—"}",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Text(
+                text = "Type: ${device.type}",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 4.dp)
+            )
+            Text(
+                text = "ID: ${device.deviceUuid}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 2.dp, bottom = 16.dp)
+            )
+
+            Text(
+                text = "Current values",
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+            if (device.state.isEmpty()) {
+                Text(
+                    text = "No state reported",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            } else {
+                device.state.entries.sortedBy { it.key }.forEach { (key, value) ->
+                    Text(
+                        text = "$key: ${formatStateValue(value)}",
+                        style = MaterialTheme.typography.bodyLarge,
+                        modifier = Modifier.padding(vertical = 4.dp)
+                    )
+                }
+            }
+
+            Text(
+                text = "Controls",
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(top = 24.dp, bottom = 8.dp)
+            )
+            DeviceCapabilityControls(
+                device = device,
+                isCommandInFlight = isCommandInFlight,
+                onBooleanCapability = { key, value ->
+                    viewModel.sendDeviceState(device, mapOf(key to value))
+                },
+                onIntegerCapability = { key, value ->
+                    viewModel.setIntegerCapability(device, key, value)
+                }
+            )
+        }
+    }
+}

--- a/apps/mobile/app/src/main/java/com/interactivehouse/mobile/ui/screens/DeviceListScreen.kt
+++ b/apps/mobile/app/src/main/java/com/interactivehouse/mobile/ui/screens/DeviceListScreen.kt
@@ -3,65 +3,131 @@ package com.interactivehouse.mobile.ui.screens
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
+import com.interactivehouse.mobile.data.DemoModeConfig
 import com.interactivehouse.mobile.data.model.Device
+import com.interactivehouse.mobile.ui.device.formatStateValue
 import com.interactivehouse.mobile.viewmodel.DeviceListViewModel
 
 @Composable
 fun DeviceListScreen(
-    viewModel: DeviceListViewModel = viewModel()
+    viewModel: DeviceListViewModel,
+    onDeviceClick: (Device) -> Unit
 ) {
     val devices by viewModel.devices.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
-    val errorMessage by viewModel.errorMessage.collectAsState()
-
-    LaunchedEffect(Unit) {
-        viewModel.loadDevices()
-    }
+    val errorMessage by viewModel.errorMessage.collectAsState() // fetching error
+    val commandSuccessMessage by viewModel.commandSuccessMessage.collectAsState()
+    val commandErrorMessage by viewModel.commandErrorMessage.collectAsState()
 
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(16.dp)
+            .padding(horizontal = 20.dp, vertical = 24.dp)
     ) {
         Text(
-            text = "Device List",
+            text = "My home",
             style = MaterialTheme.typography.headlineMedium,
-            modifier = Modifier.padding(bottom = 16.dp)
+            modifier = Modifier.padding(bottom = 4.dp)
+        )
+        Text(
+            text = "Devices",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(bottom = 20.dp)
         )
 
-        errorMessage?.let { message ->
+        // If demo mode is on show a banner
+        if (DemoModeConfig.USE_DEMO_MODE) {
             Card(
-                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.tertiaryContainer),
+                shape = RoundedCornerShape(16.dp),
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(bottom = 8.dp)
+                    .padding(bottom = 16.dp)
             ) {
                 Text(
-                    text = message,
-                    color = MaterialTheme.colorScheme.onErrorContainer,
-                    modifier = Modifier.padding(12.dp)
+                    text = "DEMO MODE — devices and commands are local (no server).",
+                    color = MaterialTheme.colorScheme.onTertiaryContainer,
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.padding(14.dp)
                 )
             }
         }
 
+        // If there is an error, show error card
+        errorMessage?.let { message ->
+            Card(
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer),
+                shape = RoundedCornerShape(16.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 12.dp)
+            ) {
+                Text(
+                    text = message,
+                    color = MaterialTheme.colorScheme.onErrorContainer,
+                    modifier = Modifier.padding(14.dp)
+                )
+            }
+        }
+
+        // Success related feedback
+        commandSuccessMessage?.let { message ->
+            Card(
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
+                shape = RoundedCornerShape(16.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 12.dp)
+            ) {
+                Text(
+                    text = message,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                    modifier = Modifier.padding(14.dp)
+                )
+            }
+        }
+
+        // Command related failures
+        commandErrorMessage?.let { message ->
+            Card(
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer),
+                shape = RoundedCornerShape(16.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 12.dp)
+            ) {
+                Text(
+                    text = message,
+                    color = MaterialTheme.colorScheme.onErrorContainer,
+                    modifier = Modifier.padding(14.dp)
+                )
+            }
+        }
+
+        // What action to show next
         when {
             isLoading -> {
                 Box(
@@ -84,10 +150,13 @@ fun DeviceListScreen(
             }
             else -> {
                 LazyColumn(
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                    verticalArrangement = Arrangement.spacedBy(14.dp)
                 ) {
                     items(devices, key = { it.deviceUuid }) { device ->
-                        DeviceItem(device = device)
+                        DeviceSummaryCard(
+                            device = device,
+                            onClick = { onDeviceClick(device) }
+                        )
                     }
                 }
             }
@@ -95,24 +164,97 @@ fun DeviceListScreen(
     }
 }
 
+// draws device card
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun DeviceItem(device: Device) {
+private fun DeviceSummaryCard(
+    device: Device,
+    onClick: () -> Unit
+) {
     Card(
+        onClick = onClick,
         modifier = Modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+        shape = RoundedCornerShape(20.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
     ) {
-        Column(modifier = Modifier.padding(16.dp)) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(18.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // show visual marker based on device type
+            DeviceTypeIconPlaceholder(type = device.type)
+            Column(modifier = Modifier.padding(start = 16.dp)) { //Contain textual info
+                // device display name
+                Text(
+                    text = device.name?.takeIf { it.isNotBlank() }
+                        ?: device.type.replaceFirstChar { it.uppercase() },
+                    style = MaterialTheme.typography.titleMedium
+                )
+                // room
+                Text(
+                    text = device.room?.takeIf { it.isNotBlank() }?.let { "Room: $it" } ?: "Room: —",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 4.dp)
+                )
+                // status
+                Text(
+                    text = deviceSummaryStatus(device),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(top = 6.dp)
+                )
+            }
+        }
+    }
+}
+
+// Creates symbol shown on each card
+@Composable
+private fun DeviceTypeIconPlaceholder(type: String) {
+    val symbol = when (type.lowercase()) {
+        "light", "lamp" -> "◯"
+        "fan" -> "⌁"
+        else -> type.take(1).uppercase()  //Use the first letter
+    }
+    // background colour behind the symbol
+    Surface(
+        modifier = Modifier.size(52.dp),
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.primaryContainer
+    ) {
+        Box(contentAlignment = Alignment.Center) {
             Text(
-                text = device.type.replaceFirstChar { it.uppercase() },
-                style = MaterialTheme.typography.titleMedium
-            )
-            Text(
-                text = device.deviceUuid,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+                text = symbol,
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onPrimaryContainer
             )
         }
     }
 }
 
+// Short status string shown on the card
+private fun deviceSummaryStatus(device: Device): String {
+    // checks whether the device state contains a power value
+    val power = device.state["power"]
+    if (power is Boolean) {
+        val extra = device.state.entries
+            .filter { it.key != "power" }
+            .sortedBy { it.key }
+            .take(1)
+            .joinToString { "${it.key} ${formatStateValue(it.value)}" }
+        return if (extra.isNotEmpty()) {
+            "${if (power) "On" else "Off"} · $extra"
+        } else {
+            if (power) "On" else "Off"
+        }
+    }
+    if (device.state.isEmpty()) return "No status"
+    return device.state.entries.sortedBy { it.key }.take(2)
+        .joinToString(" · ") { "${it.key}: ${formatStateValue(it.value)}" }
+}

--- a/apps/mobile/app/src/main/java/com/interactivehouse/mobile/ui/screens/SignupPlaceholder.kt
+++ b/apps/mobile/app/src/main/java/com/interactivehouse/mobile/ui/screens/SignupPlaceholder.kt
@@ -1,0 +1,40 @@
+package com.interactivehouse.mobile.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * Placeholder until teammate-owned registration flow is wired into navigation.
+ */
+@Composable
+fun SignupPlaceholderScreen(onBack: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Sign up",
+            style = MaterialTheme.typography.headlineMedium
+        )
+        Text(
+            text = "Registration will be available here.",
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(top = 12.dp, bottom = 24.dp)
+        )
+        Button(onClick = onBack) {
+            Text("Back")
+        }
+    }
+}

--- a/apps/mobile/app/src/main/java/com/interactivehouse/mobile/viewmodel/DeviceListViewModel.kt
+++ b/apps/mobile/app/src/main/java/com/interactivehouse/mobile/viewmodel/DeviceListViewModel.kt
@@ -4,35 +4,68 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.interactivehouse.mobile.data.model.Device
 import com.interactivehouse.mobile.data.repository.DeviceRepository
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
 class DeviceListViewModel : ViewModel() {
 
-    private val repository = DeviceRepository()
+    private val repository = DeviceRepository() // Object to talk to the data layer
 
-    private val _devices = MutableStateFlow<List<Device>>(emptyList())
-    val devices: StateFlow<List<Device>> = _devices.asStateFlow()
+    private val _devices = MutableStateFlow<List<Device>>(emptyList()) //internal mutable list of device
+    val devices: StateFlow<List<Device>> = _devices.asStateFlow() // devices exposed to the UI
 
-    private val _isLoading = MutableStateFlow(false)
+    private val _isLoading = MutableStateFlow(false) // stores whether the app is currently loading devices, starts as false then changes
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
 
     private val _errorMessage = MutableStateFlow<String?>(null)
     val errorMessage: StateFlow<String?> = _errorMessage.asStateFlow()
 
-    fun loadDevices() {
+    private val _commandSuccessMessage = MutableStateFlow<String?>(null)
+    val commandSuccessMessage: StateFlow<String?> = _commandSuccessMessage.asStateFlow()
+
+    private val _commandErrorMessage = MutableStateFlow<String?>(null) //holds error message for device loading problems
+    val commandErrorMessage: StateFlow<String?> = _commandErrorMessage.asStateFlow()
+
+    private val _isCommandInFlight = MutableStateFlow(false) // to tracks if a command is sent
+    val isCommandInFlight: StateFlow<Boolean> = _isCommandInFlight.asStateFlow()
+
+    private var refreshJob: Job? = null
+
+    /**
+     * 5s polling aligned with API guidance.
+     */
+    fun startPeriodicRefresh() {
+        if (refreshJob?.isActive == true) return // is polling running? -> exit
+        refreshJob = viewModelScope.launch {
+            while (isActive) {
+                delay(5_000)
+                loadDevices(showLoading = false)
+            }
+        }
+    }
+
+    override fun onCleared() {
+        refreshJob?.cancel()
+        super.onCleared()
+    }
+
+
+    fun loadDevices(showLoading: Boolean = true) {
         viewModelScope.launch {
-            _errorMessage.value = null
-            _isLoading.value = true
+            _errorMessage.value = null // clear any old error
+            if (showLoading) _isLoading.value = true
             try {
-                val result = repository.getDevices()
+                val result = repository.getDevices() // call repository for devices
                 _devices.value = result
             } catch (e: Exception) {
-                _errorMessage.value = e.message ?: "Failed to load devices"
+                _errorMessage.value = e.message ?: "Failed to load devices" // save error message into state
             } finally {
-                _isLoading.value = false
+                if (showLoading) _isLoading.value = false
             }
         }
     }
@@ -40,5 +73,54 @@ class DeviceListViewModel : ViewModel() {
     fun clearError() {
         _errorMessage.value = null
     }
-}
 
+    fun refreshDevices() {
+        loadDevices(showLoading = false)
+    }
+
+    /**
+     * Sends a partial state update (same contract as POST .../commands body `state`).
+     */
+    fun sendDeviceState(device: Device, statePatch: Map<String, Any>) {
+        if (statePatch.isEmpty()) return
+        viewModelScope.launch {
+            _commandSuccessMessage.value = null
+            _commandErrorMessage.value = null
+            _isCommandInFlight.value = true
+
+            try {
+                val response = repository.sendCommand(
+                    uuid = device.deviceUuid,
+                    state = statePatch
+                )
+
+                if (response.status == "success") {
+                    _commandSuccessMessage.value = formatCommandSuccess(statePatch)
+
+                    val result = repository.getDevices()
+                    _devices.value = result
+                } else {
+                    _commandErrorMessage.value =
+                        response.message ?: response.error ?: "Command failed"
+                }
+            } catch (e: Exception) {
+                _commandErrorMessage.value = e.message ?: "Command failed"
+            } finally {
+                _isCommandInFlight.value = false
+            }
+        }
+    }
+
+    fun setPower(device: Device, power: Boolean) {
+        sendDeviceState(device, mapOf("power" to power))
+    }
+
+    fun setIntegerCapability(device: Device, key: String, value: Int) {
+        sendDeviceState(device, mapOf(key to value))
+    }
+
+    private fun formatCommandSuccess(patch: Map<String, Any>): String =
+        patch.entries.joinToString(prefix = "Updated: ", separator = ", ") { (k, v) ->
+            "$k → $v"
+        }
+}

--- a/apps/mobile/gradle/libs.versions.toml
+++ b/apps/mobile/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ espressoCore = "3.7.0"
 lifecycleRuntimeKtx = "2.10.0"
 activityCompose = "1.12.4"
 composeBom = "2024.09.00"
+navigationCompose = "2.8.4"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -24,6 +25,7 @@ androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "u
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/apps/mobile/settings.gradle.kts
+++ b/apps/mobile/settings.gradle.kts
@@ -21,4 +21,3 @@ dependencyResolutionManagement {
 
 rootProject.name = "mobile"
 include(":app")
- 


### PR DESCRIPTION
Added Demo Mode with fake devices (light, fan) and local state handling Integrated backend API (Retrofit) for devices and commands Updated repository to support demo + real API modes Implemented capability-driven UI (switches, sliders) Improved device list & detail screens with dynamic rendering Fixed null crash issues from backend data
Added polling (5s refresh) for device update

## Summary
Added Demo Mode with fake devices (light, fan) and local state handling Integrated backend API (Retrofit) for devices and commands Updated repository to support demo + real API modes Implemented capability-driven UI (switches, sliders) Improved device (includes R4, R5, R6, R7 and R8)

## Why
To enable testing and demostration without relying on the backend, while preparing full integration

## Test
How did you verify it works? (e.g. "ran app and tested X")
Ran the app and verified:
 -Devices load in both demo and backend mode
 -Device controls (power, brightness, speed) update correctly
 -UI handles missing / null data without crashing

## Checklist
- [x] Small, focused change
- [x] I tested it
- [x] Linked issue/requirement if relevant

Related Issue: #114 
