### PR TITLE
Server/164 task tests for rest communication

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,33 @@
+name: PR Checks
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  web:
+    name: Web Lint and Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/web
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: apps/web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ESLint
+        run: npm run lint
+
+      - name: Build web app
+        run: npm run build

--- a/services/tests/test_rest_device_flow.py
+++ b/services/tests/test_rest_device_flow.py
@@ -1,0 +1,38 @@
+import asyncio
+
+from services.src.schemas.device_schema import CommandPayload
+from services.src.services import device_service
+
+def test_post_command_for_rest_device_queues_command(monkeypatch):
+    queued = {}
+
+    def fake_get_device(device_uuid):
+        return {
+            "device_uuid": device_uuid,
+            "transport": {
+                "mode": "rest"
+            }
+        }
+    
+    def fake_enqueue_command(device_uuid, payload):
+        queued["device_uuid"] = device_uuid
+        queued["payload"] = payload
+
+    monkeypatch.setattr(device_service.device_store, "get_device", fake_get_device)
+    monkeypatch.setattr(device_service.device_store, "enqueue_command", fake_enqueue_command)
+
+    payload = CommandPayload(state={"power": "on"})
+
+    result = asyncio.run(device_service.post_command("DEVICE_01", payload))
+
+    assert result["message"] == "Command dispatched"
+    assert result["device_uuid"] == "DEVICE_01"
+    assert result["sent"] is True
+    assert result["delivery"] == "queued"
+
+    assert queued["device_uuid"] == "DEVICE_01"
+    assert queued["payload"] == {
+        "type": "COMMAND",
+        "device_uuid": "DEVICE_01",
+        "state": {"power": "on"},
+    }

--- a/services/tests/test_rest_device_flow.py
+++ b/services/tests/test_rest_device_flow.py
@@ -4,9 +4,15 @@ from services.src.schemas.device_schema import CommandPayload
 from services.src.services import device_service
 
 def test_post_command_for_rest_device_queues_command(monkeypatch):
+    # This test tests the flow of:
+    # 1. The service receives a command for a device that uses REST transport.
+    # 2. The service looks up the device and sees it uses REST.
+    # 3. The service queues the command instead of sending it to the bridge.
     queued = {}
 
     def fake_get_device(device_uuid):
+        # Fake the device lookup so the test does not depend on Firebase.
+        # Returning a REST transport should make the service choose the queue path.
         return {
             "device_uuid": device_uuid,
             "transport": {
@@ -15,21 +21,27 @@ def test_post_command_for_rest_device_queues_command(monkeypatch):
         }
     
     def fake_enqueue_command(device_uuid, payload):
+        # Fake the queue write by saving the values locally,
+        # so the test can verify what would have been queued.
         queued["device_uuid"] = device_uuid
         queued["payload"] = payload
 
+    # Replace the real store functions with fake ones to isolate service logic.
     monkeypatch.setattr(device_service.device_store, "get_device", fake_get_device)
     monkeypatch.setattr(device_service.device_store, "enqueue_command", fake_enqueue_command)
 
     payload = CommandPayload(state={"power": "on"})
 
+    # post_command is async, so the test needs to run it with asyncio.
     result = asyncio.run(device_service.post_command("DEVICE_01", payload))
 
+    # Verify the response returned from the service.
     assert result["message"] == "Command dispatched"
     assert result["device_uuid"] == "DEVICE_01"
     assert result["sent"] is True
     assert result["delivery"] == "queued"
 
+    # Verify the command payload that was "queued" for the device.
     assert queued["device_uuid"] == "DEVICE_01"
     assert queued["payload"] == {
         "type": "COMMAND",


### PR DESCRIPTION
## Summary
Adds a basic GitHub Actions PR check for the web app.
The workflow runs `npm ci`, `npm run lint`, and `npm run build` for `apps/web` on pull requests to `main`.

Also adds an initial unit test for the REST device command flow in `services/tests`.

## Why
We want automatic PR validation for the web app and a starting point for backend tests around REST-based device communication.

## Test
Ran `npm run lint` in `apps/web`
Ran `npm run build` in `apps/web`
Ran `python -m pytest services/tests/test_rest_device_flow.py -q`

## Checklist
- [x] Small, focused change
- [x] I tested it
- [x] Linked issue/requirement if relevant

Related Issue: #164 
