### PR TITLE
Fixed database overwrite error

### DIFF
--- a/services/src/services/device_service.py
+++ b/services/src/services/device_service.py
@@ -24,7 +24,7 @@ def is_device_online(device: dict) -> bool:
 
 
 def connect_device(payload: ConnectDeviceBody) -> Dict[str, Any]:
-    data = payload.model_dump()
+    data = payload.model_dump(exclude_unset=True)
     devices = data.get("devices", {})
 
     connected_devices: Dict[str, Dict[str, Any]] = {}


### PR DESCRIPTION
## Summary
Changes the write method to when connecting a device to exclude empty fields. 

## Why
Earlier if the server retreived empty fields from already registered devices, it wrote empty fields as null instead of ignoring them. 

## Test
Ran the server and registered a already registered device again.

## Checklist
- [x] Small, focused change
- [x] I tested it
- [x] Linked issue/requirement if relevant

Related Issue: #168 
