### PR TITLE
Smaller fixes. Check PR description.

### DIFF
--- a/devices/RVC/RVC_Rest.py
+++ b/devices/RVC/RVC_Rest.py
@@ -1,6 +1,5 @@
 import requests
 import rvc_protocol_adapter as protocol
-from datetime import datetime, timezone
 import os
 import json
 
@@ -19,7 +18,7 @@ class RVCRestAdapter:
         self.is_registered = self._load_registration_status()
 
     def _load_registration_status(self):
-        config_file = "./devices/RVC/cfg.json"
+        config_file = "cfg.json"
 
         if os.path.exists(config_file):
             with open(config_file, "r") as f:
@@ -29,24 +28,25 @@ class RVCRestAdapter:
         return False
 
     def _save_registration_status(self):
-        config_file = "./devices/RVC/cfg.json"
+        config_file = "cfg.json"
         with open(config_file, "w") as f:
             json.dump({"is_registered": self.is_registered}, f)
 
     def connect(self):
         try:
             url = f"{self.base_url}/connect"
+
             if not self.is_registered:
                 payload = self.protocol.build_device_entry()
-                self.is_registered = True
-                self._save_registration_status()
             else:
                 payload = self.protocol.build_connect_message()
 
-            response = self.session.post(url, json=payload)
-            print(f"Response status code: {response.status_code}")
-            print(f"Response text: {response.text}")  # Print raw response
-            return response.status_code, response.json()  # This will fail if response.text is empty or invalid JSON
+            response = self.session.post(url, json=payload, timeout=5)
+            if response.status_code == 200:
+                self.is_registered = True
+                self._save_registration_status()
+
+            return response.status_code, response.json()
 
         except Exception as e:
             print(f"Error during connect: {e}")
@@ -56,19 +56,8 @@ class RVCRestAdapter:
     def send_heartbeat(self):
         try:
             url = f"{self.base_url}/{self.rvc.device_id}/heartbeat"
-            response = self.session.post(url)
-            print(f"Heartbeat response status code: {response.status_code}")
-            print(f"Heartbeat response text: {response.text}")
-
-            if not response.text.strip():
-                print("Empty response from server")
-                return response.status_code, {"error": "Empty response"}
-
-            try:
-                return response.status_code, response.json()
-            except ValueError as e:
-                print(f"Invalid JSON response: {e}")
-                return response.status_code, {"error": "Invalid JSON"}
+            response = self.session.post(url, timeout=5)
+            return response.status_code, response.json()
 
         except Exception as e:
             print(f"Error sending heartbeat: {e}")
@@ -94,7 +83,7 @@ class RVCRestAdapter:
     def send_command_ack(self, payload: dict):
         try:
             url = f"{self.base_url}/{self.rvc.device_id}/command-ack"
-            response = self.session.post(url, json=payload)
+            response = self.session.post(url, json=payload, timeout=5)
             return response.status_code, response.json()
          
         except Exception as e:
@@ -104,7 +93,7 @@ class RVCRestAdapter:
     def poll_next_command(self):
         try:
             url = f"{self.base_url}/{self.rvc.device_id}/commands/next"
-            response = self.session.get(url)
+            response = self.session.get(url, timeout=5)
 
             if response.status_code == 200:
                 return response.json().get("command")

--- a/devices/RVC/simulation.py
+++ b/devices/RVC/simulation.py
@@ -1,36 +1,54 @@
 from RVC import RVC
 from RVC_Rest import RVCRestAdapter
+import signal
 import threading
-import time
+
+stop_event = threading.Event()
+
 
 def heartbeat_loop(rest_adapter):
-    while True:
+    while not stop_event.is_set():
         rest_adapter.send_heartbeat()
-        time.sleep(5)
+        stop_event.wait(5)
+
 
 def command_loop(rest_adapter):
-    while True:
+    while not stop_event.is_set():
         command = rest_adapter.poll_next_command()
         if command:
             print(f"Received command: {command}")
             ack = rest_adapter.apply_command(command)
             rest_adapter.send_command_ack(ack)
-        time.sleep(0.5)
+        stop_event.wait(0.5)
+
+
+def handle_shutdown(signum, frame):
+    print("Stopping simulation...", flush=True)
+    stop_event.set()
 
 
 if __name__ == "__main__":
+    signal.signal(signal.SIGINT, handle_shutdown)
+    signal.signal(signal.SIGTERM, handle_shutdown)
+
     rvc = RVC(device_id="RVC001", name="RoboVac", grid_size=10)
     rest_adapter = RVCRestAdapter(rvc, base_url="https://knolly-svetlana-beribboned.ngrok-free.dev/api/v1/device-gateway")
     rest_adapter.connect()
 
-    heartbeat_thread = threading.Thread(target=heartbeat_loop, args=(rest_adapter,), daemon=True)
+    heartbeat_thread = threading.Thread(target=heartbeat_loop, args=(rest_adapter,))
     heartbeat_thread.start()
 
-    command_thread = threading.Thread(target=command_loop, args=(rest_adapter,), daemon=True)
+    command_thread = threading.Thread(target=command_loop, args=(rest_adapter,))
     command_thread.start()
 
-    heartbeat_thread.join()
-    command_thread.join()
+    try:
+        while heartbeat_thread.is_alive() or command_thread.is_alive():
+            heartbeat_thread.join(timeout=0.5)
+            command_thread.join(timeout=0.5)
+    except KeyboardInterrupt:
+        handle_shutdown(None, None)
+        heartbeat_thread.join(timeout=2)
+        command_thread.join(timeout=2)
 
 
     # manual testing of RVC functionality


### PR DESCRIPTION
## Summary
- `is_registered` is saved after sucessfull `connect()`
- request timeouts added into REST-calls
- `cfg.json` -path is restored. Just needs to be run from `/devices/RVC`
- Fixed shutdown as `simulator.py` wouldn't exit on some computers.
  
## Why
To fix last REST connections and shutdown.

## Test
1. Started server
2. Started app
3. Started `simulator.py`
### Result:
Showed correct logs, updated successfully in the database, and showed correct status in the app.

## Checklist
- [x] Small, focused change
- [x] I tested it
- [x] Linked issue/requirement if relevant

Related Issue: #176 
