### PR TITLE
UNIT Bug - Fix crash after login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 *.py[cod]
 *tmpclaude*
 .idea/
+tmp-logcat.txt

--- a/apps/mobile/app/src/main/java/com/interactivehouse/mobile/data/model/Device.kt
+++ b/apps/mobile/app/src/main/java/com/interactivehouse/mobile/data/model/Device.kt
@@ -13,8 +13,11 @@ data class Device(
     val room: String?,
     val type: String,
     val capabilities: Map<String, CapabilitySpec>,
-    val state: Map<String, Any>
-)
+    val state: Map<String, Any>? = emptyMap()
+) {
+    val stateOrEmpty: Map<String, Any>
+        get() = state.orEmpty()
+}
 
 /**
  * Describes a device capability (e.g. "power": { "type": "boolean", "writable": true }).

--- a/apps/mobile/app/src/main/java/com/interactivehouse/mobile/ui/device/DeviceCapabilityControls.kt
+++ b/apps/mobile/app/src/main/java/com/interactivehouse/mobile/ui/device/DeviceCapabilityControls.kt
@@ -61,7 +61,7 @@ private fun CapabilityControlRow(
 ) {
     when (spec.type) {
         "boolean" -> {
-            val current = (device.state[capabilityKey] as? Boolean) ?: false
+            val current = (device.stateOrEmpty[capabilityKey] as? Boolean) ?: false
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier.padding(top = 12.dp)
@@ -82,7 +82,7 @@ private fun CapabilityControlRow(
             val min = spec.min ?: 0
             val max = spec.max ?: 100
             val fallback = ((min + max) / 2).coerceIn(min, max)
-            val current = device.state[capabilityKey].toUiInt(fallback, min, max)
+            val current = device.stateOrEmpty[capabilityKey].toUiInt(fallback, min, max)
             Column(modifier = Modifier.padding(top = 12.dp)) {
                 Text(
                     text = "${capabilityKey.replaceFirstChar { it.uppercase() }} — $current",

--- a/apps/mobile/app/src/main/java/com/interactivehouse/mobile/ui/screens/DeviceDetailScreen.kt
+++ b/apps/mobile/app/src/main/java/com/interactivehouse/mobile/ui/screens/DeviceDetailScreen.kt
@@ -126,14 +126,15 @@ fun DeviceDetailScreen(
                 style = MaterialTheme.typography.titleMedium,
                 modifier = Modifier.padding(bottom = 8.dp)
             )
-            if (device.state.isEmpty()) {
+            val state = device.stateOrEmpty
+            if (state.isEmpty()) {
                 Text(
                     text = "No state reported",
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             } else {
-                device.state.entries.sortedBy { it.key }.forEach { (key, value) ->
+                state.entries.sortedBy { it.key }.forEach { (key, value) ->
                     Text(
                         text = "$key: ${formatStateValue(value)}",
                         style = MaterialTheme.typography.bodyLarge,

--- a/apps/mobile/app/src/main/java/com/interactivehouse/mobile/ui/screens/DeviceListScreen.kt
+++ b/apps/mobile/app/src/main/java/com/interactivehouse/mobile/ui/screens/DeviceListScreen.kt
@@ -240,10 +240,11 @@ private fun DeviceTypeIconPlaceholder(type: String) {
 
 // Short status string shown on the card
 private fun deviceSummaryStatus(device: Device): String {
+    val state = device.stateOrEmpty
     // checks whether the device state contains a power value
-    val power = device.state["power"]
+    val power = state["power"]
     if (power is Boolean) {
-        val extra = device.state.entries
+        val extra = state.entries
             .filter { it.key != "power" }
             .sortedBy { it.key }
             .take(1)
@@ -254,7 +255,7 @@ private fun deviceSummaryStatus(device: Device): String {
             if (power) "On" else "Off"
         }
     }
-    if (device.state.isEmpty()) return "No status"
-    return device.state.entries.sortedBy { it.key }.take(2)
+    if (state.isEmpty()) return "No status"
+    return state.entries.sortedBy { it.key }.take(2)
         .joinToString(" · ") { "${it.key}: ${formatStateValue(it.value)}" }
 }


### PR DESCRIPTION
## Summary
This PR makes a small fix in the Android app to stop it from crashing after login when the device list is loaded.

The issue was that some devices from the backend did not have any `state` data. The app expected that data to always exist, which caused a crash when opening the device list.

This PR adds a safe fallback for missing state values, so the app now shows a normal status like `No status` instead of crashing.

## Why
The app was crashing after login during normal testing, which blocked the device list flow in the Android app.

## Test
Tested the Android app after login against the temporary backend/ngrok URL.
Verified that:
- the app no longer crashes
- the device list opens correctly
- devices without state are shown safely instead of breaking the app

## Checklist
- [x] Small, focused change
- [x] I tested it
- [x] Linked issue/requirement if relevant

Related Issue: #184
