### PR TITLE
docs: add docstrings to all functions in device_store.py

### DIFF
--- a/services/src/firebase/device_store.py
+++ b/services/src/firebase/device_store.py
@@ -9,22 +9,40 @@ PENDING_COMMANDS_PATH = "pending_commands"
 
 
 def _devices_ref():
+    """Returns a Firebase reference to the root devices node."""
     return get_ref(DEVICES_PATH)
 
 
 def _device_ref(device_uuid: str):
+    """Returns a Firebase reference to a specific device node by UUID."""
     return get_ref(f"{DEVICES_PATH}/{device_uuid}")
 
 
 def _pending_commands_ref(device_uuid: str):
+    """Returns a Firebase reference to the pending commands queue for a specific device."""
     return get_ref(f"{PENDING_COMMANDS_PATH}/{device_uuid}")
 
 
 def _now_iso() -> str:
+    """Returns the current UTC time as an ISO 8601 formatted string."""
     return datetime.now(timezone.utc).isoformat()
 
 
 def _build_device(device_uuid: str, data: Dict[str, Any], existing: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """
+    Builds a complete device dictionary by merging new data with existing data.
+
+    If existing data is provided, fields are merged rather than replaced.
+    The device is always marked as connected=True when built.
+
+    Args:
+        device_uuid: The unique identifier of the device.
+        data: New data to apply to the device.
+        existing: Optional existing device data to merge with.
+
+    Returns:
+        A complete device dictionary ready to be stored in Firebase.
+    """
     existing = existing or {}
 
     status = existing.get("status", {}).copy()
@@ -43,16 +61,50 @@ def _build_device(device_uuid: str, data: Dict[str, Any], existing: Optional[Dic
 
 
 def get_device(device_uuid: str) -> Dict[str, Any] | None:
+    """
+    Retrieves a single device from Firebase by UUID.
+
+    Args:
+        device_uuid: The unique identifier of the device.
+
+    Returns:
+        The device dictionary, or None if not found.
+    """
     return _device_ref(device_uuid).get()
 
 
 def register_device(device_uuid: str, data: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Registers a new device in Firebase.
+
+    Builds a complete device object from the provided data and stores it.
+
+    Args:
+        device_uuid: The unique identifier of the device.
+        data: Device data including type, transport, capabilities, and state.
+
+    Returns:
+        The registered device dictionary.
+    """
     device = _build_device(device_uuid, data)
     _device_ref(device_uuid).set(device)
     return device
 
 
 def update_device(device_uuid: str, data: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Updates an existing device in Firebase by merging new data with existing data.
+
+    Args:
+        device_uuid: The unique identifier of the device.
+        data: New data to merge into the existing device.
+
+    Returns:
+        The updated device dictionary.
+
+    Raises:
+        ValueError: If the device does not exist in Firebase.
+    """
     existing = get_device(device_uuid)
 
     if not existing:
@@ -64,11 +116,26 @@ def update_device(device_uuid: str, data: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def list_devices() -> list[Dict[str, Any]]:
+    """
+    Returns a list of all registered devices from Firebase.
+
+    Returns:
+        A list of device dictionaries. Returns an empty list if no devices exist.
+    """
     devices = _devices_ref().get() or {}
     return list(devices.values())
 
 
 def delete_device(device_uuid: str) -> Dict[str, Any] | None:
+    """
+    Deletes a device and its pending commands from Firebase.
+
+    Args:
+        device_uuid: The unique identifier of the device to delete.
+
+    Returns:
+        The deleted device dictionary, or None if the device was not found.
+    """
     device = get_device(device_uuid)
     if not device:
         return None
@@ -79,6 +146,18 @@ def delete_device(device_uuid: str) -> Dict[str, Any] | None:
 
 
 def update_last_seen(device_uuid: str, timestamp: datetime) -> Dict[str, Any]:
+    """
+    Updates the last_seen timestamp of a device and marks it as connected.
+
+    Called on each heartbeat received from a device.
+
+    Args:
+        device_uuid: The unique identifier of the device.
+        timestamp: The datetime of the most recent heartbeat.
+
+    Returns:
+        The updated device dictionary, or an error dict if the device was not found.
+    """
     device = get_device(device_uuid)
     if not device:
         return {"error": "device not found", "device_uuid": device_uuid}
@@ -96,6 +175,20 @@ def update_device_state(
     reported_state: Dict[str, Any],
     status: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any] | None:
+    """
+    Updates the state of a device in Firebase.
+
+    Merges the reported state with the existing state. Also updates
+    the device's connected status and last_seen timestamp.
+
+    Args:
+        device_uuid: The unique identifier of the device.
+        reported_state: A dictionary of state key-value pairs to merge.
+        status: Optional status fields to merge into the device's status.
+
+    Returns:
+        The updated device dictionary, or None if the device was not found.
+    """
     device = get_device(device_uuid)
     if not device:
         return None
@@ -116,10 +209,30 @@ def update_device_state(
 
 
 def enqueue_command(device_uuid: str, payload: Dict[str, Any]) -> None:
+    """
+    Adds a command to the pending commands queue for a device in Firebase.
+
+    Commands are pushed to the queue and consumed in order by the device.
+
+    Args:
+        device_uuid: The unique identifier of the target device.
+        payload: The command payload to enqueue.
+    """
     _pending_commands_ref(device_uuid).push(payload)
 
 
 def pop_next_command(device_uuid: str) -> Dict[str, Any] | None:
+    """
+    Retrieves and removes the next pending command for a device from Firebase.
+
+    Commands are consumed in FIFO order based on their Firebase push keys.
+
+    Args:
+        device_uuid: The unique identifier of the device.
+
+    Returns:
+        The next command payload, or None if the queue is empty.
+    """
     queue = _pending_commands_ref(device_uuid).get() or {}
     if not queue:
         return None
@@ -133,8 +246,17 @@ def pop_next_command(device_uuid: str) -> Dict[str, Any] | None:
 def mark_stale_devices_offline(threshold_seconds: int = 30) -> list[str]:
     """
     Checks all devices in Firebase and marks them as offline (connected=False)
-    if their last_seen is older than threshold_seconds.
-    Returns a list of device_uuids that were marked offline.
+    if their last_seen timestamp is older than the given threshold.
+
+    This function is called on each heartbeat to ensure stale device states
+    do not persist in the system. Implements the mitigation for Risk R9.
+
+    Args:
+        threshold_seconds: Number of seconds without a heartbeat before a
+                           device is considered offline. Defaults to 30.
+
+    Returns:
+        A list of device_uuids that were marked offline in this sweep.
     """
     now = datetime.now(timezone.utc)
     marked_offline = []
@@ -165,4 +287,3 @@ def mark_stale_devices_offline(threshold_seconds: int = 30) -> list[str]:
 
     return marked_offline
 
-    


### PR DESCRIPTION
## Summary
Added docstrings to all functions in `services/src/firebase/device_store.py` to improve code readability and maintainability.

## Why
Part of Issue #193 – Add Documentation. The device store contains core Firebase logic for device state management and command dispatch, and lacked inline documentation.

## Test
Ran all existing tests with `python3 -m pytest services/tests/ -v` – 26/26 passed.

## Checklist
- [x] Small, focused change
- [x] I tested it
- [x] Linked issue/requirement if relevant

Related Issue: #195
