### PR TITLE
docs: add docstrings to device_service.py

### DIFF
--- a/services/src/services/device_service.py
+++ b/services/src/services/device_service.py
@@ -6,11 +6,21 @@ from fastapi import HTTPException
 from typing import Any, Dict
 from services.src.bridge.bridge import dispatch_command
 
-
 OFFLINE_THRESHOLD_SECONDS = 30
 
 
 def is_device_online(device: dict) -> bool:
+    """Check whether a device is considered online based on its last_seen timestamp.
+
+    A device is considered online if its last_seen timestamp is within
+    OFFLINE_THRESHOLD_SECONDS of the current UTC time.
+
+    Args:
+        device (dict): A device dictionary containing at least a 'last_seen' ISO 8601 timestamp.
+
+    Returns:
+        bool: True if the device is online, False if it is offline or has no last_seen value.
+    """
     last_seen = device.get("last_seen")
 
     if not last_seen:
@@ -24,6 +34,22 @@ def is_device_online(device: dict) -> bool:
 
 
 def connect_device(payload: ConnectDeviceBody) -> Dict[str, Any]:
+    """Register or update one or more devices from a connection payload.
+
+    For each device in the payload, if a device_uuid is provided and already
+    exists in Firebase, the device is updated. If no device_uuid is provided,
+    a new UUID is generated and the device is registered.
+
+    Args:
+        payload (ConnectDeviceBody): The request body containing a dictionary
+            of devices to connect, each with optional device_uuid and device data.
+
+    Returns:
+        Dict[str, Any]: A dictionary containing:
+            - message (str): Confirmation message.
+            - devices (dict): The saved device data keyed by device_uuid.
+            - generated_uuids (dict): Any newly generated UUIDs keyed by device key.
+    """
     data = payload.model_dump(exclude_unset=True)
     devices = data.get("devices", {})
 
@@ -55,6 +81,18 @@ def connect_device(payload: ConnectDeviceBody) -> Dict[str, Any]:
 
 
 def list_devices(device_type: str | None = None):
+    """Retrieve all registered devices, optionally filtered by device type.
+
+    Fetches all devices from Firebase and appends an is_online field to each
+    device based on the last_seen timestamp.
+
+    Args:
+        device_type (str | None): Optional device type to filter by.
+            If None, all devices are returned.
+
+    Returns:
+        list[dict]: A list of device dictionaries, each including an is_online field.
+    """
     devices = device_store.list_devices()
 
     if device_type:
@@ -67,6 +105,20 @@ def list_devices(device_type: str | None = None):
 
 
 def get_device(device_uuid: str) -> Dict[str, Any]:
+    """Retrieve a single device by its UUID.
+
+    Fetches the device from Firebase and appends an is_online field based
+    on the last_seen timestamp.
+
+    Args:
+        device_uuid (str): The unique identifier of the device.
+
+    Raises:
+        HTTPException: 404 if no device with the given UUID exists.
+
+    Returns:
+        Dict[str, Any]: The device data dictionary including an is_online field.
+    """
     device = device_store.get_device(device_uuid)
 
     if not device:
@@ -78,6 +130,19 @@ def get_device(device_uuid: str) -> Dict[str, Any]:
 
 
 def delete_device(device_uuid: str) -> dict[str, str]:
+    """Delete a device from Firebase by its UUID.
+
+    Args:
+        device_uuid (str): The unique identifier of the device to delete.
+
+    Raises:
+        HTTPException: 404 if no device with the given UUID exists.
+
+    Returns:
+        dict[str, str]: A confirmation dictionary containing:
+            - message (str): Confirmation message.
+            - device_uuid (str): The UUID of the deleted device.
+    """
     device = device_store.delete_device(device_uuid)
 
     if not device:
@@ -90,6 +155,22 @@ def delete_device(device_uuid: str) -> dict[str, str]:
 
 
 def heartbeat(device_uuid: str):
+    """Update the last_seen timestamp for a device and sweep for stale devices.
+
+    Called by a device to signal that it is still active. Updates the device's
+    last_seen field in Firebase to the current UTC time. After updating, triggers
+    a sweep to mark any devices that have not sent a heartbeat within
+    OFFLINE_THRESHOLD_SECONDS as offline.
+
+    Args:
+        device_uuid (str): The unique identifier of the device sending the heartbeat.
+
+    Raises:
+        HTTPException: 404 if no device with the given UUID exists.
+
+    Returns:
+        dict: The result from updating the last_seen timestamp in Firebase.
+    """
     now = datetime.now(timezone.utc)
     result = device_store.update_last_seen(device_uuid, now)
 
@@ -102,8 +183,24 @@ def heartbeat(device_uuid: str):
     return result
 
 
-
 def get_next_command(device_uuid: str) -> Dict[str, Any]:
+    """Retrieve and remove the next pending command for a device.
+
+    Checks that the device exists in Firebase, then pops the next command
+    from the device's command queue. Returns None as the command value if
+    the queue is empty.
+
+    Args:
+        device_uuid (str): The unique identifier of the device.
+
+    Raises:
+        HTTPException: 404 if no device with the given UUID exists.
+
+    Returns:
+        Dict[str, Any]: A dictionary containing:
+            - device_uuid (str): The device's UUID.
+            - command (dict | None): The next command payload, or None if the queue is empty.
+    """
     device = device_store.get_device(device_uuid)
     if not device:
         raise HTTPException(status_code=404, detail="Device not found")
@@ -116,6 +213,26 @@ def get_next_command(device_uuid: str) -> Dict[str, Any]:
 
 
 def handle_command_ack(device_uuid: str, status: str, reported_state: Dict[str, Any]) -> Dict[str, Any]:
+    """Handle a command acknowledgement from a device.
+
+    Updates the device's reported state and records the last command status
+    in Firebase after the device has executed a command.
+
+    Args:
+        device_uuid (str): The unique identifier of the device.
+        status (str): The result status of the command execution (e.g. 'ok', 'error').
+        reported_state (Dict[str, Any]): The device's current state as reported after execution.
+
+    Raises:
+        HTTPException: 404 if no device with the given UUID exists.
+
+    Returns:
+        Dict[str, Any]: A dictionary containing:
+            - message (str): Confirmation message.
+            - device_uuid (str): The device's UUID.
+            - status (str): The reported command status.
+            - reported_state (dict): The device's reported state.
+    """
     device = device_store.update_device_state(
         device_uuid,
         reported_state,
@@ -134,6 +251,27 @@ def handle_command_ack(device_uuid: str, status: str, reported_state: Dict[str, 
 
 
 async def post_command(device_uuid: str, payload: CommandPayload) -> Dict[str, Any]:
+    """Dispatch a command to a device via REST queue or the bridge.
+
+    Determines the transport mode for the device. If the device uses REST
+    transport, the command is enqueued in Firebase for the device to poll.
+    Otherwise, the command is dispatched immediately via the bridge service.
+
+    Args:
+        device_uuid (str): The unique identifier of the target device.
+        payload (CommandPayload): The command payload containing the desired state.
+
+    Raises:
+        HTTPException: 404 if no device with the given UUID exists.
+
+    Returns:
+        Dict[str, Any]: A dictionary containing:
+            - message (str): Confirmation message.
+            - device_uuid (str): The target device's UUID.
+            - sent (bool): Whether the command was successfully dispatched.
+            - delivery (str): Delivery method used, either 'queued' or 'bridge'.
+            - payload (dict): The full command payload that was sent.
+    """
     device = device_store.get_device(device_uuid)
 
     if not device:


### PR DESCRIPTION
## Summary
Added Google-style docstrings to all 10 functions in `services/src/services/device_service.py`.

## Why
Part of the documentation effort for the Server team (Issue #193). `device_service.py` handles all device business logic but had no docstrings, making it harder to understand without reading the full implementation.

## Test
Ran all 26 existing tests with `python -m pytest services/tests/ -v` – all passed.

## Checklist
- [x] Small, focused change
- [x] I tested it
- [x] Linked issue/requirement if relevant

Related Issue: #197

