### PR TITLE
SERVER - Connected Auth to Protected Routes

### DIFF
--- a/services/src/routes/device_routes.py
+++ b/services/src/routes/device_routes.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, Depends
+from services.src.dependencies.auth import current_user
 from services.src.dependencies.auth import optional_user
 from services.src.schemas.device_schema import CommandPayload
 from services.src.controllers import device_controller as controller
@@ -14,15 +15,15 @@ router = APIRouter(
 # -------------------------
 
 @router.get("")
-def list_devices(type: str | None = None, user=Depends(optional_user)):
+def list_devices(type: str | None = None, user=Depends(current_user)):
     return controller.list_devices(type=type)
 
 @router.get("/{device_uuid}")
-def get_device(device_uuid: str, user=Depends(optional_user)):
+def get_device(device_uuid: str, user=Depends(current_user)):
     return controller.get_device(device_uuid=device_uuid)
 
 @router.delete("/{device_uuid}")
-def delete_device(device_uuid: str, user=Depends(optional_user)):
+def delete_device(device_uuid: str, user=Depends(current_user)):
     return controller.delete_device(device_uuid=device_uuid)
 
 # -------------------------
@@ -30,7 +31,7 @@ def delete_device(device_uuid: str, user=Depends(optional_user)):
 # -------------------------
 
 @router.post("/{device_uuid}/commands")
-async def post_command(device_uuid: str, payload: CommandPayload, user=Depends(optional_user)):
+async def post_command(device_uuid: str, payload: CommandPayload, user=Depends(current_user)):
     return await controller.post_command(device_uuid=device_uuid, payload=payload)
 
 # -------------------------

--- a/services/src/routes/state_routes.py
+++ b/services/src/routes/state_routes.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, Depends
+from services.src.dependencies.auth import current_user
 from services.src.dependencies.auth import optional_user
 from services.src.controllers import state_controller as controller
 
@@ -12,9 +13,9 @@ router = APIRouter(
 # -------------------------
 
 @router.get("/{device_uuid}/state")
-def get_state(device_uuid: str, user=Depends(optional_user)):
+def get_state(device_uuid: str, user=Depends(current_user)):
     return controller.get_state(device_uuid=device_uuid)
 
 @router.patch("/{device_uuid}/state")
-def patch_state(device_uuid: str, updates: dict, user=Depends(optional_user)):
+def patch_state(device_uuid: str, updates: dict, user=Depends(current_user)):
     return controller.patch_state(device_uuid=device_uuid, updates=updates)

--- a/services/tests/test_route_auth_protection.py
+++ b/services/tests/test_route_auth_protection.py
@@ -1,0 +1,44 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from services.src.main import app
+from services.src.controllers import device_controller, state_controller # Controllers are mocked
+
+# These tests check that the device and state routes actually require auth.
+# The controllers are mocked because this file is only about route protection.
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+@pytest.mark.parametrize("method,path,json_body", [
+    ("GET", "/api/v1/devices", None), 
+    ("GET", "/api/v1/devices/DEVICE_01", None), 
+    ("DELETE", "/api/v1/devices/DEVICE_01", None), 
+    ("POST", "/api/v1/devices/DEVICE_01/commands", {"state": {"power": "on"}}),
+    ("GET", "/api/v1/devices/DEVICE_01/state", None),
+    ("PATCH", "/api/v1/devices/DEVICE_01/state", {"state": {"power": "on"}}),
+])
+def test_protected_routes_reject_invalid_token(client, monkeypatch, method, path, json_body):
+
+    monkeypatch.setattr(device_controller, "list_devices", lambda type=None: {"ok": True})
+    monkeypatch.setattr(device_controller, "get_device", lambda device_uuid: {"ok": True})
+    monkeypatch.setattr(device_controller, "delete_device", lambda device_uuid: {"ok": True})
+
+    async def fake_post_command(device_uuid, payload):
+        return {"ok": True}
+    
+    monkeypatch.setattr(device_controller, "post_command", fake_post_command)
+
+    monkeypatch.setattr(state_controller, "get_state", lambda device_uuid: {"ok": True})
+    monkeypatch.setattr(state_controller, "patch_state", lambda device_uuid, updates: {"ok": True})
+
+    response = client.request(
+        method,
+        path,
+        json=json_body,
+        headers={"Authorization": "Bearer invalid-token"},
+    )
+
+    # All protected routes should return '401 Unauthorized' for an invalid token.
+    assert response.status_code == 401


### PR DESCRIPTION
`Ready to merge. Waiting for the right time.`

## Summary
Adds auth protection to the device and state routes.

These routes now use `current_user`, which means requests with a bad bearer token are stopped before they reach the controller logic.

I also added tests for the affected device and state endpoints, so we can catch it if one of these routes accidentally becomes unprotected again.
## Why
This is part of connecting authentication/authorization to the actual server routes.
To protect the routes from unauthorized use.
## Test
Ran:
```powershell
python -m pytest .\services\tests\test_route_auth_protection.py -q
```
Result:
```powershell
6 passed
```
## Checklist
- [x] Small, focused change
- [x] I tested it
- [x] Linked issue/requirement if relevant

Related Issue: #192 

