### PR TITLE
Added validation for command keys against device capabilities

### DIFF
--- a/services/src/services/device_service.py
+++ b/services/src/services/device_service.py
@@ -277,6 +277,20 @@ async def post_command(device_uuid: str, payload: CommandPayload) -> Dict[str, A
     if not device:
         raise HTTPException(status_code=404, detail="Device not found")
 
+    requested_keys = set(payload.state.keys())
+    supported_keys = set(device.get("capabilities", {}).keys())
+    unsupported_keys = requested_keys - supported_keys
+
+    if unsupported_keys:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "unsupported_capability",
+                "message": "device does not support one or more requested state fields",
+                "unsupported_keys": sorted(unsupported_keys),
+            },
+        )
+
     command_payload = {
         "type": "COMMAND",
         "device_uuid": device_uuid,

--- a/services/tests/test_rest_device_flow.py
+++ b/services/tests/test_rest_device_flow.py
@@ -1,7 +1,11 @@
 import asyncio
 
+import pytest
+from fastapi import HTTPException
+
 from services.src.schemas.device_schema import CommandPayload
 from services.src.services import device_service
+
 
 def test_post_command_for_rest_device_queues_command(monkeypatch):
     # This test tests the flow of:
@@ -17,9 +21,15 @@ def test_post_command_for_rest_device_queues_command(monkeypatch):
             "device_uuid": device_uuid,
             "transport": {
                 "mode": "rest"
-            }
+            },
+            "capabilities": {
+                "power": {
+                    "type": "boolean",
+                    "writable": True,
+                },
+            },
         }
-    
+
     def fake_enqueue_command(device_uuid, payload):
         # Fake the queue write by saving the values locally,
         # so the test can verify what would have been queued.
@@ -48,3 +58,41 @@ def test_post_command_for_rest_device_queues_command(monkeypatch):
         "device_uuid": "DEVICE_01",
         "state": {"power": "on"},
     }
+
+
+def test_post_command_rejects_unsupported_state_keys(monkeypatch):
+    queued = {}
+
+    def fake_get_device(device_uuid):
+        return {
+            "device_uuid": device_uuid,
+            "transport": {
+                "mode": "rest"
+            },
+            "capabilities": {
+                "power": {
+                    "type": "boolean",
+                    "writable": True,
+                },
+            },
+        }
+
+    def fake_enqueue_command(device_uuid, payload):
+        queued["device_uuid"] = device_uuid
+        queued["payload"] = payload
+
+    monkeypatch.setattr(device_service.device_store, "get_device", fake_get_device)
+    monkeypatch.setattr(device_service.device_store, "enqueue_command", fake_enqueue_command)
+
+    payload = CommandPayload(state={"banana": "yes"})
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(device_service.post_command("DEVICE_01", payload))
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == {
+        "error": "unsupported_capability",
+        "message": "device does not support one or more requested state fields",
+        "unsupported_keys": ["banana"],
+    }
+    assert queued == {}


### PR DESCRIPTION
## Summary
Validates command state keys against the target device's declared capabilities.

## Why
Prevents unsupported command keys, like `banana`, from being queued or sent to devices.

## Test
Ran `.\services\.venv\Scripts\python.exe -m pytest services\tests`

## Checklist
- [x] Small, focused change
- [x] I tested it
- [x] Linked issue/requirement if relevant

Related Issue: #199
