### PR TITLE
219 task make sure both rvc and fan run at the same time

### DIFF
--- a/cfg.json
+++ b/cfg.json
@@ -1,0 +1,1 @@
+{"is_registered": true}

--- a/devices/Fan/rest_gateway.py
+++ b/devices/Fan/rest_gateway.py
@@ -1,6 +1,6 @@
 import time
 import requests
-from fan_controller import FanController
+from Fan.fan_controller import FanController
 
 DEVICE_UUID = "FAN001"
 

--- a/devices/Fan/rest_gateway.py
+++ b/devices/Fan/rest_gateway.py
@@ -2,112 +2,128 @@ import time
 import requests
 from fan_controller import FanController
 
-SERVER_URL = "http://localhost:8000"  # ändra om behövs
 DEVICE_UUID = "FAN001"
 
-fan = FanController()
+class FanRestAdapter:
+    def __init__(self, fan, base_url):
+        self.fan = fan
+        self.base_url = base_url
 
-
-def connect_device():
-    payload = {
-        "devices": {
-            DEVICE_UUID: {
-                "device_uuid": DEVICE_UUID,
-                "type": "fan",
-                "transport": {
-                    "mode": "rest",
-                    "protocol": "rest"
-                },
-                "capabilities": {
-                    "power": {"type": "boolean", "writable": True},
-                    "speed_up": {"type": "boolean", "writable": True},
-                    "speed_down": {"type": "boolean", "writable": True},
-                    "mode_next": {"type": "boolean", "writable": True},
-                    "timer_next": {"type": "boolean", "writable": True},
-                    "swing_toggle": {"type": "boolean", "writable": True}
-                },
-                "state": fan.get_status(),
-                "status": {
-                    "connected": True
+    def connect_device(self):
+        payload = {
+            "devices": {
+                DEVICE_UUID: {
+                    "device_uuid": DEVICE_UUID,
+                    "type": "fan",
+                    "transport": {
+                        "mode": "rest",
+                        "protocol": "rest"
+                    },
+                    "capabilities": {
+                        "power": {"type": "boolean", "writable": True},
+                        "speed_up": {"type": "boolean", "writable": True},
+                        "speed_down": {"type": "boolean", "writable": True},
+                        "mode_next": {"type": "boolean", "writable": True},
+                        "timer_next": {"type": "boolean", "writable": True},
+                        "swing_toggle": {"type": "boolean", "writable": True}
+                    },
+                    "state": self.fan.get_status(),
+                    "status": {
+                        "connected": True
+                    }
                 }
             }
         }
-    }
 
-    r = requests.post(
-        f"{SERVER_URL}/api/v1/device-gateway/connect",
-        json=payload
-    )
-    print("Connect:", r.status_code, r.text)
-
-
-def heartbeat():
-    try:
         r = requests.post(
-            f"{SERVER_URL}/api/v1/device-gateway/{DEVICE_UUID}/heartbeat"
+            f"{self.base_url}/connect",
+            json=payload
         )
-        print("Heartbeat:", r.status_code)
-    except Exception as e:
-        print("Heartbeat error:", e)
+        print("Connect:", r.status_code, r.text)
 
 
-def get_command():
-    try:
-        r = requests.get(
-            f"{SERVER_URL}/api/v1/device-gateway/{DEVICE_UUID}/commands/next"
+    def heartbeat(self):
+        try:
+            r = requests.post(
+                f"{self.base_url}/{DEVICE_UUID}/heartbeat"
+            )
+            print("Heartbeat:", r.status_code)
+        except Exception as e:
+            print("Heartbeat error:", e)
+
+
+    def get_command(self):
+        try:
+            r = requests.get(
+                f"{self.base_url}/{DEVICE_UUID}/commands/next"
+            )
+            data = r.json()
+            return data.get("command")
+        except Exception as e:
+            print("Command fetch error:", e)
+            return None
+
+
+    def ack_command(self, state):
+        payload = {
+            "status": "ok",
+            "reported_state": state
+        }
+
+        r = requests.post(
+            f"{self.base_url}/{DEVICE_UUID}/command-ack",
+            json=payload
         )
-        data = r.json()
-        return data.get("command")
-    except Exception as e:
-        print("Command fetch error:", e)
-        return None
+        print("ACK:", r.status_code)
+
+    def apply_command(self, command_payload):
+        if command_payload.get("type") != "COMMAND":
+            return {"status": "error", "error": "Invalid message type"}
+        
+        if command_payload.get("device_uuid") != DEVICE_UUID:
+            return {"status": "error", "error": "Wrong device_uuid"}
+
+        state = command_payload.get("state", {})
+
+        try:
+            new_state = self.fan.apply_state(state)
+            return {"status": "ok", "reported_state": new_state}
+        except Exception as e:
+            return {"status": "error", "error": str(e)}
 
 
-def ack_command(state):
-    payload = {
-        "status": "ok",
-        "reported_state": state
-    }
+    def main(self):
+        print("Starting REST Gateway...")
 
-    r = requests.post(
-        f"{SERVER_URL}/api/v1/device-gateway/{DEVICE_UUID}/command-ack",
-        json=payload
-    )
-    print("ACK:", r.status_code)
+        self.connect_device()
 
+        last_heartbeat = 0
 
-def main():
-    print("Starting REST Gateway...")
+        while True:
+            now = time.time()
 
-    connect_device()
+            # 🔁 heartbeat var 5 sek
+            if now - last_heartbeat >= 5:
+                self.heartbeat()
+                last_heartbeat = now
 
-    last_heartbeat = 0
+            # 🔁 hämta command
+            command = self.get_command()
 
-    while True:
-        now = time.time()
+            if command:
+                print("Received command:", command)
 
-        # 🔁 heartbeat var 5 sek
-        if now - last_heartbeat >= 5:
-            heartbeat()
-            last_heartbeat = now
+                requested_state = command.get("state", {})
 
-        # 🔁 hämta command
-        command = get_command()
+                new_state = self.fan.apply_state(requested_state)
 
-        if command:
-            print("Received command:", command)
+                self.ack_command(new_state)
 
-            requested_state = command.get("state", {})
-
-            new_state = fan.apply_state(requested_state)
-
-            ack_command(new_state)
-
-        time.sleep(1)
+            time.sleep(1)
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    finally:
-        fan.close()
+    fan = FanController()
+    rest_adapter = FanRestAdapter(fan, base_url="http://localhost:8000/api/v1/device-gateway")
+    rest_adapter.main()
+

--- a/devices/RVC/RVC.py
+++ b/devices/RVC/RVC.py
@@ -117,7 +117,6 @@ class RVC:
         for step in path[1:]:
             self.position = step
             self.cleaned_cells.add(step)
-            self.visualize()
             time.sleep(0.12)
 
         self.status = "idle"

--- a/devices/RVC/RVC.py
+++ b/devices/RVC/RVC.py
@@ -69,6 +69,7 @@ class RVC:
         if self.status == "idle":
             self.status = "cleaning"
             self.low_battery_triggered = False
+            self.cleaned_cells = {self.position}
             print(f"{self.name} has started cleaning.")
         elif self.status == "paused":
             self.resume()

--- a/devices/RVC/RVC_Rest.py
+++ b/devices/RVC/RVC_Rest.py
@@ -53,7 +53,7 @@ class RVCRestAdapter:
             return None, None
         
 
-    def send_heartbeat(self):
+    def heartbeat(self):
         try:
             url = f"{self.base_url}/{self.rvc.device_id}/heartbeat"
             response = self.session.post(url, timeout=5)
@@ -80,7 +80,7 @@ class RVCRestAdapter:
             return self.protocol.build_command_ack(status="error", error=str(e))
 
 
-    def send_command_ack(self, payload: dict):
+    def ack_command(self, payload: dict):
         try:
             url = f"{self.base_url}/{self.rvc.device_id}/command-ack"
             response = self.session.post(url, json=payload, timeout=5)
@@ -90,7 +90,7 @@ class RVCRestAdapter:
             print(f"Error sending command ack: {e}")
             return None, None
         
-    def poll_next_command(self):
+    def get_command(self):
         try:
             url = f"{self.base_url}/{self.rvc.device_id}/commands/next"
             response = self.session.get(url, timeout=5)

--- a/devices/RVC/mock_server.py
+++ b/devices/RVC/mock_server.py
@@ -2,7 +2,7 @@ from flask import Flask, jsonify, request
 
 app = Flask(__name__)
 
-command = None
+command_queues = {}
 device_states = {}
 connected_devices = {}
 
@@ -33,20 +33,8 @@ def heartbeat(device_uuid):
 
 @app.route("/api/v1/device-gateway/<device_uuid>/commands/next", methods=["GET"])
 def next_command(device_uuid):
-    global command
-
-    if command:
-        cmd = command
-        command = None
-        return jsonify({
-            "device_uuid": device_uuid,
-            "command": cmd
-        })
-
-    return jsonify({
-        "device_uuid": device_uuid,
-        "command": None
-    })
+    cmd = command_queues.pop(device_uuid, None)
+    return jsonify({"device_uuid": device_uuid, "command": cmd})
 
 
 @app.route("/api/v1/device-gateway/<device_uuid>/command-ack", methods=["POST"])
@@ -71,16 +59,11 @@ def ack(device_uuid):
 
 @app.route("/send-command", methods=["POST"])
 def send_command():
-    global command
-    command = request.json
-
-    print("Command queued:")
-    print(command)
-
-    return jsonify({
-        "status": "queued",
-        "command": command
-    })
+    data = request.json
+    device_uuid = data.get("device_uuid")
+    command_queues[device_uuid] = data
+    print("Command queued:", data)
+    return jsonify({"status": "queued", "command": data})
 
 
 @app.route("/state", methods=["GET"])

--- a/devices/RVC/simulation.py
+++ b/devices/RVC/simulation.py
@@ -49,7 +49,7 @@ if __name__ == "__main__":
 
     print("Starting devices...")
 
-    rvc = RVC(device_id="RVC001", name="RoboVac", grid_size=10)#
+    rvc = RVC(device_id="RVC001", name="RoboVac")
 
     rvc.rest_adapter = RVCRestAdapter(
         rvc, 
@@ -91,7 +91,7 @@ if __name__ == "__main__":
         while any(t.is_alive() for t in threads):
             rvc.visualize()
             for t in threads:
-                t.join(timeout=0.1)
+                t.join(timeout=0.016)
     except KeyboardInterrupt:
         handle_shutdown(None, None)
         for t in threads:

--- a/devices/RVC/simulation.py
+++ b/devices/RVC/simulation.py
@@ -1,7 +1,6 @@
 import time
-
-#from RVC import RVC
-#from RVC_Rest import RVCRestAdapter
+from RVC import RVC
+from RVC_Rest import RVCRestAdapter
 import signal
 import threading
 from devices.Fan.fan_controller import FanController
@@ -12,18 +11,23 @@ stop_event = threading.Event()
 
 def heartbeat_loop(rest_adapter):
     while not stop_event.is_set():
-        rest_adapter.send_heartbeat()
+        rest_adapter.heartbeat()
         stop_event.wait(5)
 
 
 def command_loop(rest_adapter):
     while not stop_event.is_set():
-        command = rest_adapter.poll_next_command()
+        command = rest_adapter.get_command()
         if command:
             print(f"Received command: {command}")
             ack = rest_adapter.apply_command(command)
-            rest_adapter.send_command_ack(ack)
+            rest_adapter.ack_command(ack)
         stop_event.wait(0.5)
+
+def rvc_tick_loop(rvc):
+    while not stop_event.is_set():
+        rvc.tick(time.time())
+        stop_event.wait(0.1)
 
 
 def handle_shutdown(signum, frame):
@@ -35,89 +39,51 @@ if __name__ == "__main__":
     signal.signal(signal.SIGINT, handle_shutdown)
     signal.signal(signal.SIGTERM, handle_shutdown)
 
-
-    #rvc = RVC(device_id="RVC001", name="RoboVac", grid_size=10)#
-    """
-    rest_adapter = RVCRestAdapter(rvc, base_url="https://knolly-svetlana-beribboned.ngrok-free.dev/api/v1/device-gateway")
-    rest_adapter.connect()
-
-    
-    heartbeat_thread = threading.Thread(target=heartbeat_loop, args=(rest_adapter,))
-    heartbeat_thread.start()
-
-    command_thread = threading.Thread(target=command_loop, args=(rest_adapter,))
-    command_thread.start()
-
-    try:
-        while heartbeat_thread.is_alive() or command_thread.is_alive():
-            heartbeat_thread.join(timeout=0.5)
-            command_thread.join(timeout=0.5)
-    except KeyboardInterrupt:
-        handle_shutdown(None, None)
-        heartbeat_thread.join(timeout=2)
-        command_thread.join(timeout=2)
-
-
-    # manual testing of RVC functionality
-    """
-    # if rvc.visualizer:
-    #     rvc.visualizer.initialize_plot(rvc.name)
-
-    # rvc.start()
-    # rvc.visualize()
-
-    # steps = 0
-
-    # for _ in range(100):
-    #     rvc.move()
-    #     rvc.visualize()
-    #     print(steps)
-    #     steps += 1
-    #     if steps == 20:
-    #         rvc.pause()
-    #         time.sleep(5)
-    #         rvc.resume()
-        
-    # rvc.dock()
+    rvc = RVC(device_id="RVC001", name="RoboVac", grid_size=10)#
+    rvc.rest_adapter = RVCRestAdapter(
+        rvc, 
+        base_url="https://knolly-svetlana-beribboned.ngrok-free.dev/api/v1/device-gateway"
+    )
+    rvc.rest_adapter.connect()
 
     fan = FanController()
-
     fan_adapter = FanRestAdapter(
         fan,
-        device_id="FAN001",
         base_url="http://localhost:8000/api/v1/device-gateway"
     )
+    fan_adapter.connect_device()
 
-    fan_adapter.connect()
+    heartbeat_thread_rvc = threading.Thread(target=heartbeat_loop, args=(rvc.rest_adapter,))
+    heartbeat_thread_rvc.start()
 
-    heartbeat_thread_fan = threading.Thread(
-        target=heartbeat_loop,
-        args=(fan_adapter,)
-    )
+    command_thread_rvc = threading.Thread(target=command_loop, args=(rvc.rest_adapter,))
+    command_thread_rvc.start()
 
-    command_thread_fan = threading.Thread(
-        target=command_loop,
-        args=(fan_adapter,)
-    )
+    rvc_tick_thread = threading.Thread(target=rvc_tick_loop, args=(rvc,))
+    rvc_tick_thread.start()
 
+    heartbeat_thread_fan = threading.Thread(target=heartbeat_loop, args=(fan_adapter,))
     heartbeat_thread_fan.start()
+
+    command_thread_fan = threading.Thread(target=command_loop, args=(fan_adapter,))
     command_thread_fan.start()
 
-    try:
-        while (
-            heartbeat_thread_fan.is_alive()
-            or command_thread_fan.is_alive()
-        ):
-            heartbeat_thread_fan.join(timeout=0.5)
-            command_thread_fan.join(timeout=0.5)
+    threads = [
+        heartbeat_thread_rvc,
+        command_thread_rvc,
+        rvc_tick_thread,
+        heartbeat_thread_fan,
+        command_thread_fan
+    ]
 
+    try:
+        while any(t.is_alive() for t in threads):
+            for t in threads:
+                t.join(timeout=0.5)
     except KeyboardInterrupt:
         handle_shutdown(None, None)
-
+        for t in threads:
+            t.join(timeout=2)
     finally:
         stop_event.set()
         fan.close()
-
-        
-
-    

--- a/devices/RVC/simulation.py
+++ b/devices/RVC/simulation.py
@@ -1,13 +1,21 @@
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
 import time
 from RVC import RVC
 from RVC_Rest import RVCRestAdapter
 import signal
 import threading
-from devices.Fan.fan_controller import FanController
-from devices.Fan.rest_gateway import FanRestAdapter
+from Fan.fan_controller import FanController
+from Fan.rest_gateway import FanRestAdapter
+
+from small_mock import MockFanController
 
 stop_event = threading.Event()
 
+URL = "https://knolly-svetlana-beribboned.ngrok-free.dev/api/v1/device-gateway"
+TEST_URL = "http://localhost:8000/api/v1/device-gateway"
 
 def heartbeat_loop(rest_adapter):
     while not stop_event.is_set():
@@ -39,17 +47,20 @@ if __name__ == "__main__":
     signal.signal(signal.SIGINT, handle_shutdown)
     signal.signal(signal.SIGTERM, handle_shutdown)
 
+    print("Starting devices...")
+
     rvc = RVC(device_id="RVC001", name="RoboVac", grid_size=10)#
+
     rvc.rest_adapter = RVCRestAdapter(
         rvc, 
-        base_url="https://knolly-svetlana-beribboned.ngrok-free.dev/api/v1/device-gateway"
+        base_url=TEST_URL
     )
     rvc.rest_adapter.connect()
 
-    fan = FanController()
+    fan = MockFanController() # Replace with FanController() for real fan
     fan_adapter = FanRestAdapter(
         fan,
-        base_url="http://localhost:8000/api/v1/device-gateway"
+        base_url=TEST_URL
     )
     fan_adapter.connect_device()
 
@@ -78,8 +89,9 @@ if __name__ == "__main__":
 
     try:
         while any(t.is_alive() for t in threads):
+            rvc.visualize()
             for t in threads:
-                t.join(timeout=0.5)
+                t.join(timeout=0.1)
     except KeyboardInterrupt:
         handle_shutdown(None, None)
         for t in threads:

--- a/devices/RVC/small_mock.py
+++ b/devices/RVC/small_mock.py
@@ -1,0 +1,80 @@
+class MockRestAdapter:
+    def __init__(self, device_id):
+        self.device_id = device_id
+
+    def heartbeat(self):
+        print(f"[MOCK] Heartbeat sent for {self.device_id}")
+
+    def get_command(self):
+        return None  # or return a hardcoded command to test handling
+
+    def apply_command(self, payload):
+        return {"status": "ok", "reported_state": {}}
+
+    def ack_command(self, payload):
+        print(f"[MOCK] ACK sent: {payload}")
+
+    def connect(self):
+        print(f"[MOCK] Connected {self.device_id}")
+
+    def connect_device(self):
+        print(f"[MOCK] Connected {self.device_id}")
+
+class MockFanController:
+    def __init__(self):
+        self.state = {
+            "power": False,
+            "speed": 4,
+            "mode": "normal",
+            "timer": None,
+            "swing": False
+        }
+        print("[MOCK FAN] Initialized")
+
+    def power_on(self):
+        self.state.update({"power": True, "speed": 4, "mode": "normal", "timer": None})
+        print("[MOCK FAN] Power ON")
+
+    def power_off(self):
+        self.state["power"] = False
+        print("[MOCK FAN] Power OFF")
+
+    def speed_up(self):
+        if self.state["speed"] < 7:
+            self.state["speed"] += 1
+            print(f"[MOCK FAN] Speed up -> {self.state['speed']}")
+
+    def speed_down(self):
+        if self.state["speed"] > 1:
+            self.state["speed"] -= 1
+            print(f"[MOCK FAN] Speed down -> {self.state['speed']}")
+
+    def mode_next(self):
+        modes = ["normal", "sleep", "nature"]
+        self.state["mode"] = modes[(modes.index(self.state["mode"]) + 1) % len(modes)]
+        print(f"[MOCK FAN] Mode -> {self.state['mode']}")
+
+    def timer_next(self):
+        timers = [None, "0.5h", "1h", "2h", "4h"]
+        self.state["timer"] = timers[(timers.index(self.state["timer"]) + 1) % len(timers)]
+        print(f"[MOCK FAN] Timer -> {self.state['timer']}")
+
+    def toggle_swing(self):
+        self.state["swing"] = not self.state["swing"]
+        print(f"[MOCK FAN] Swing -> {self.state['swing']}")
+
+    def apply_state(self, requested_state):
+        if "power" in requested_state:
+            self.power_on() if requested_state["power"] else self.power_off()
+        if requested_state.get("speed_up"): self.speed_up()
+        if requested_state.get("speed_down"): self.speed_down()
+        if requested_state.get("mode_next"): self.mode_next()
+        if requested_state.get("timer_next"): self.timer_next()
+        if requested_state.get("swing_toggle"): self.toggle_swing()
+        return self.state
+
+    def get_status(self):
+        return self.state
+
+    def close(self):
+        print("[MOCK FAN] Closed")

--- a/devices/RVC/test_rvc_rest.py
+++ b/devices/RVC/test_rvc_rest.py
@@ -129,7 +129,7 @@ class TestRVCRestAdapter(unittest.TestCase):
         self.adapter.session.post.return_value.status_code = 200
         self.adapter.session.post.return_value.json.return_value = {"status": "ok"}
 
-        status_code, response = self.adapter.send_heartbeat()
+        status_code, response = self.adapter.heartbeat()
 
         self.assertEqual(status_code, 200)
         self.assertEqual(response, {"status": "ok"})
@@ -143,7 +143,7 @@ class TestRVCRestAdapter(unittest.TestCase):
             "command": {"type": "COMMAND", "device_uuid": "RVC001", "state": {"cleaning": True}}
         }
 
-        command = self.adapter.poll_next_command()
+        command = self.adapter.get_command()
 
         self.assertEqual(command, {"type": "COMMAND", "device_uuid": "RVC001", "state": {"cleaning": True}})
 
@@ -156,7 +156,7 @@ class TestRVCRestAdapter(unittest.TestCase):
             "command": None
         }
 
-        command = self.adapter.poll_next_command()
+        command = self.adapter.get_command()
 
         self.assertIsNone(command)
 
@@ -233,7 +233,7 @@ class TestRVCRestAdapter(unittest.TestCase):
         self.adapter.session.post.return_value.status_code = 200
         self.adapter.session.post.return_value.json.return_value = {"status": "ok"}
 
-        status_code, response = self.adapter.send_command_ack()
+        status_code, response = self.adapter.ack_command()
 
         self.assertEqual(status_code, 200)
         self.assertEqual(response, {"status": "ok"})


### PR DESCRIPTION
## Summary
The fans rest gateway got messed up in a merge conflict, this has been fixed. RVC_REST got it's function names updated to match with the fans rest gateway for easier integration in simulation.py simulation.py got a new loop for the RVCs tick thread which also got added. Some variables got renamed for consistency and the thread joining logic looks better now. test file for rvc rest got their functions refactored to match the updated names.

Also fixed a couple of bugs regarding the RVC, such asthe RVC visualization crashing and the RVC phasing through objects.

## Test
Tested against mocked server

## Checklist
- [x] Small, focused change
- [x] I tested it
- [x] Linked issue/requirement if relevant

Related Issue: #219 
